### PR TITLE
External exemplars, more predictions images, more parametrized inference...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+**.ini
+**.pth
+!weights/FSC147.pth
+**__pycache__
+.idea/
+/data/*
+!/data/foring00025.png
+!/data/letsea_14/annotations_few.json
+!/data/letsea_14/annotations_zero.json
+!/data/letsea_14/split.json

--- a/FSC_test_cross(few-shot).py
+++ b/FSC_test_cross(few-shot).py
@@ -5,9 +5,10 @@ import numpy as np
 import os
 import time
 from pathlib import Path
-from PIL import Image
+from PIL import Image, ImageDraw
 import matplotlib.pyplot as plt
 import scipy.ndimage as ndimage
+import pandas as pd
 
 import torch
 import torch.nn as nn
@@ -16,10 +17,9 @@ from torch.utils.data import Dataset
 import torchvision
 from torchvision import transforms
 import torchvision.transforms.functional as TF
-
 import timm
 
-assert timm.__version__ == "0.3.2"  # version check
+assert "0.4.5" <= timm.__version__ <= "0.4.9"  # version check
 
 import util.misc as misc
 import models_mae_cross
@@ -61,7 +61,12 @@ def get_args_parser():
     # Dataset parameters
     parser.add_argument('--data_path', default='/GPFS/data/changliu/FSC147/', type=str,
                         help='dataset path')
-
+    parser.add_argument('--anno_file', default='annotation_FSC147_384.json', type=str,
+                        help='annotation json file')
+    parser.add_argument('--data_split_file', default='Train_Test_Val_FSC_147.json', type=str,
+                        help='data split json file')
+    parser.add_argument('--im_dir', default='images_384_VarV2', type=str,
+                        help='images directory')
     parser.add_argument('--output_dir', default='./Image',
                         help='path where to save, empty for no saving')
     parser.add_argument('--log_dir', default='./Image',
@@ -71,16 +76,22 @@ def get_args_parser():
     parser.add_argument('--seed', default=0, type=int)
     parser.add_argument('--resume', default='./output_fim6_dir/checkpoint-0.pth',
                         help='resume from checkpoint')
+    parser.add_argument('--external', default=False,
+                        help='True if using external exemplars')
+    parser.add_argument('--box_bound', default=-1, type=int,
+                        help='The max number of exemplars to be considered')
 
+    # Training parameters
     parser.add_argument('--start_epoch', default=0, type=int, metavar='N',
                         help='start epoch')
     parser.add_argument('--num_workers', default=10, type=int)
     parser.add_argument('--pin_mem', action='store_true',
                         help='Pin CPU memory in DataLoader for more efficient (sometimes) transfer to GPU.')
     parser.add_argument('--no_pin_mem', action='store_false', dest='pin_mem')
+    parser.add_argument('--normalization', default=True, help='Set to False to disable test-time normalization')
     parser.set_defaults(pin_mem=True)
 
-    # distributed training parameters
+    # Distributed training parameters
     parser.add_argument('--world_size', default=1, type=int,
                         help='number of distributed processes')
     parser.add_argument('--local_rank', default=-1, type=int)
@@ -92,24 +103,51 @@ def get_args_parser():
 
 os.environ["CUDA_LAUNCH_BLOCKING"] = '1'
 
-# load data from FSC147
-data_path = '/GPFS/data/changliu/FSC147/'
-anno_file = data_path + 'annotation_FSC147_384.json'
-data_split_file = data_path + 'Train_Test_Val_FSC_147.json'
-im_dir = data_path + 'images_384_VarV2'
-gt_dir = data_path + 'gt_density_map_adaptive_384_VarV2'
-
-with open(anno_file) as f:
-    annotations = json.load(f)
-
-with open(data_split_file) as f:
-    data_split = json.load(f)
 
 class TestData(Dataset):
-    def __init__(self):
-        
+    def __init__(self, external: bool, box_bound: int = -1):
+
         self.img = data_split['test']
         self.img_dir = im_dir
+        self.external = external
+        self.box_bound = box_bound
+
+        if external:
+            self.external_boxes = []
+            for anno in annotations:
+                rects = []
+                bboxes = annotations[anno]['box_examples_coordinates']
+
+                if bboxes:
+                    image = Image.open('{}/{}'.format(im_dir, anno))
+                    image.load()
+                    W, H = image.size
+
+                    new_H = 384
+                    new_W = 16 * int((W / H * 384) / 16)
+                    scale_factor_W = float(new_W) / W
+                    scale_factor_H = float(new_H) / H
+                    image = transforms.Resize((new_H, new_W))(image)
+                    Normalize = transforms.Compose([transforms.ToTensor()])
+                    image = Normalize(image)
+
+                    for bbox in bboxes:
+                        x1 = int(bbox[0][0] * scale_factor_W)
+                        y1 = int(bbox[0][1] * scale_factor_H)
+                        x2 = int(bbox[1][0] * scale_factor_W)
+                        y2 = int(bbox[1][1] * scale_factor_H)
+                        rects.append([y1, x1, y2, x2])
+
+                    for box in rects:
+                        box2 = [int(k) for k in box]
+                        y1, x1, y2, x2 = box2[0], box2[1], box2[2], box2[3]
+                        bbox = image[:, y1:y2 + 1, x1:x2 + 1]
+                        bbox = transforms.Resize((64, 64))(bbox)
+                        self.external_boxes.append(bbox.numpy())
+
+            self.external_boxes = np.array(self.external_boxes if self.box_bound < 0 else
+                                           self.external_boxes[:self.box_bound])
+            self.external_boxes = torch.Tensor(self.external_boxes)
 
     def __len__(self):
         return len(self.img)
@@ -117,54 +155,57 @@ class TestData(Dataset):
     def __getitem__(self, idx):
         im_id = self.img[idx]
         anno = annotations[im_id]
-        bboxes = anno['box_examples_coordinates']
-
+        bboxes = anno['box_examples_coordinates'] if self.box_bound < 0 else \
+            anno['box_examples_coordinates'][:self.box_bound]
         dots = np.array(anno['points'])
 
         image = Image.open('{}/{}'.format(im_dir, im_id))
-        image.load() 
+        image.load()
         W, H = image.size
 
-        new_H = 16*int(H/16)
-        new_W = 16*int(W/16)
-        scale_factor = float(new_W)/ W
+        new_H = 384
+        new_W = 16 * int((W / H * 384) / 16)
+        scale_factor_W = float(new_W) / W
+        scale_factor_H = float(new_H) / H
         image = transforms.Resize((new_H, new_W))(image)
         Normalize = transforms.Compose([transforms.ToTensor()])
         image = Normalize(image)
 
-        rects = list()
-        for bbox in bboxes:
-            x1 = int(bbox[0][0]*scale_factor)
-            y1 = bbox[0][1]
-            x2 = int(bbox[2][0]*scale_factor)
-            y2 = bbox[2][1]
-            rects.append([y1, x1, y2, x2])
-
         boxes = list()
-        cnt = 0
-        for box in rects:
-            cnt+=1
-            if cnt>3:
-                break
-            box2 = [int(k) for k in box]
-            y1, x1, y2, x2 = box2[0], box2[1], box2[2], box2[3]
-            bbox = image[:,y1:y2+1,x1:x2+1]
-            bbox = transforms.Resize((64, 64))(bbox)
-            boxes.append(bbox.numpy())
+        if self.external:
+            boxes = self.external_boxes
+        else:
+            rects = list()
+            for bbox in bboxes:
+                x1 = int(bbox[0][0] * scale_factor_W)
+                y1 = int(bbox[0][1] * scale_factor_H)
+                x2 = int(bbox[1][0] * scale_factor_W)
+                y2 = int(bbox[1][1] * scale_factor_H)
+                rects.append([y1, x1, y2, x2])
 
-        boxes = np.array(boxes)
-        boxes = torch.Tensor(boxes)
+            for box in rects:
+                box2 = [int(k) for k in box]
+                y1, x1, y2, x2 = box2[0], box2[1], box2[2], box2[3]
+                bbox = image[:, y1:y2 + 1, x1:x2 + 1]
+                bbox = transforms.Resize((64, 64))(bbox)
+                boxes.append(bbox.numpy())
+
+            boxes = np.array(boxes)
+            boxes = torch.Tensor(boxes)
+
+        if self.box_bound >= 0:
+            assert len(boxes) <= self.box_bound
 
         # Only for visualisation purpose, no need for ground truth density map indeed.
-        gt_map = np.zeros((image.shape[1], image.shape[2]),dtype='float32')
+        gt_map = np.zeros((image.shape[1], image.shape[2]), dtype='float32')
         for i in range(dots.shape[0]):
-            gt_map[min(new_H-1,int(dots[i][1]))][min(new_W-1,int(dots[i][0]*scale_factor))]=1
+            gt_map[min(new_H - 1, int(dots[i][1] * scale_factor_H))][min(new_W - 1, int(dots[i][0] * scale_factor_W))] = 1
         gt_map = ndimage.gaussian_filter(gt_map, sigma=(1, 1), order=0)
         gt_map = torch.from_numpy(gt_map)
-        gt_map = gt_map *60
-        
-        sample = {'image':image,'dots':dots, 'boxes':boxes, 'pos':rects, 'gt_map':gt_map}
-        return sample['image'], sample['dots'], sample['boxes'], sample['pos'] ,sample['gt_map']
+        gt_map = gt_map * 60
+
+        sample = {'image': image, 'dots': dots, 'boxes': boxes, 'pos': rects if self.external is False else [], 'gt_map': gt_map, 'name': im_id}
+        return sample['image'], sample['dots'], sample['boxes'], sample['pos'], sample['gt_map'], sample['name']
 
 
 def main(args):
@@ -182,7 +223,7 @@ def main(args):
 
     cudnn.benchmark = True
 
-    dataset_test = TestData()
+    dataset_test = TestData(args.external, args.box_bound)
     print(dataset_test)
 
     if True:  # args.distributed:
@@ -202,7 +243,7 @@ def main(args):
         pin_memory=args.pin_mem,
         drop_last=False,
     )
-    
+
     # define the model
     model = models_mae_cross.__dict__[args.model](norm_pix_loss=args.norm_pix_loss)
 
@@ -220,7 +261,7 @@ def main(args):
 
     print(f"Start testing.")
     start_time = time.time()
-    
+
     # test
     epoch = 0
     model.eval()
@@ -231,136 +272,166 @@ def main(args):
     # some parameters in training
     train_mae = 0
     train_rmse = 0
-    pred_cnt = 0
-    gt_cnt = 0
 
     loss_array = []
     gt_array = []
-    
-    for data_iter_step, (samples, gt_dots, boxes, pos, gt_map) in enumerate(metric_logger.log_every(data_loader_test, print_freq, header)):
+    pred_arr = []
+    name_arr = []
 
+    for data_iter_step, (samples, gt_dots, boxes, pos, gt_map, im_name) in \
+            enumerate(metric_logger.log_every(data_loader_test, print_freq, header)):
+
+        im_name = Path(im_name[0])
         samples = samples.to(device, non_blocking=True)
         gt_dots = gt_dots.to(device, non_blocking=True).half()
         boxes = boxes.to(device, non_blocking=True)
-        pos = pos
-        gt_map = gt_map.to(device, non_blocking=True)
-        
-        _,_,h,w = samples.shape 
+        num_boxes = boxes.shape[1] if boxes.nelement() > 0 else 0
+        _, _, h, w = samples.shape
 
         r_cnt = 0
         s_cnt = 0
         for rect in pos:
-            r_cnt+=1
-            if r_cnt>3:
+            r_cnt += 1
+            if r_cnt > 3:
                 break
-            if rect[2]-rect[0]<10 and rect[3] - rect[1]<10:
-                s_cnt +=1
-        
-        if s_cnt >=1:
-            r_images = []
-            r_images.append(TF.crop(samples[0], 0, 0, int(h/3), int(w/3)))
-            r_images.append(TF.crop(samples[0], int(h/3), 0, int(h/3), int(w/3)))
-            r_images.append(TF.crop(samples[0], 0, int(w/3), int(h/3), int(w/3)))
-            r_images.append(TF.crop(samples[0], int(h/3), int(w/3), int(h/3), int(w/3)))
-            r_images.append(TF.crop(samples[0], int(h*2/3), 0, int(h/3), int(w/3)))
-            r_images.append(TF.crop(samples[0], int(h*2/3), int(w/3), int(h/3), int(w/3)))
-            r_images.append(TF.crop(samples[0], 0, int(w*2/3), int(h/3), int(w/3)))
-            r_images.append(TF.crop(samples[0], int(h/3), int(w*2/3), int(h/3), int(w/3)))
-            r_images.append(TF.crop(samples[0], int(h*2/3), int(w*2/3), int(h/3), int(w/3)))
+            if rect[2] - rect[0] < 10 and rect[3] - rect[1] < 10:
+                s_cnt += 1
 
+        if s_cnt >= 1:
+            r_images = []
+            r_densities = []
+            r_images.append(TF.crop(samples[0], 0, 0, int(h / 3), int(w / 3)))
+            r_images.append(TF.crop(samples[0], int(h / 3), 0, int(h / 3), int(w / 3)))
+            r_images.append(TF.crop(samples[0], 0, int(w / 3), int(h / 3), int(w / 3)))
+            r_images.append(TF.crop(samples[0], int(h / 3), int(w / 3), int(h / 3), int(w / 3)))
+            r_images.append(TF.crop(samples[0], int(h * 2 / 3), 0, int(h / 3), int(w / 3)))
+            r_images.append(TF.crop(samples[0], int(h * 2 / 3), int(w / 3), int(h / 3), int(w / 3)))
+            r_images.append(TF.crop(samples[0], 0, int(w * 2 / 3), int(h / 3), int(w / 3)))
+            r_images.append(TF.crop(samples[0], int(h / 3), int(w * 2 / 3), int(h / 3), int(w / 3)))
+            r_images.append(TF.crop(samples[0], int(h * 2 / 3), int(w * 2 / 3), int(h / 3), int(w / 3)))
 
             pred_cnt = 0
             for r_image in r_images:
                 r_image = transforms.Resize((h, w))(r_image).unsqueeze(0)
-                density_map = torch.zeros([h,w])
+                density_map = torch.zeros([h, w])
                 density_map = density_map.to(device, non_blocking=True)
                 start = 0
                 prev = -1
-                
+
                 with torch.no_grad():
                     while start + 383 < w:
-                        output, = model(r_image[:,:,:,start:start+384], boxes, 3)
-                        output=output.squeeze(0)
-                        b1 = nn.ZeroPad2d(padding=(start, w-prev-1, 0, 0))
-                        d1 = b1(output[:,0:prev-start+1])
-                        b2 = nn.ZeroPad2d(padding=(prev+1, w-start-384, 0, 0))
-                        d2 = b2(output[:,prev-start+1:384])            
-                        
-                        b3 = nn.ZeroPad2d(padding=(0, w-start, 0, 0))
-                        density_map_l = b3(density_map[:,0:start])
-                        density_map_m = b1(density_map[:,start:prev+1])
-                        b4 = nn.ZeroPad2d(padding=(prev+1, 0, 0, 0))
-                        density_map_r = b4(density_map[:,prev+1:w])
+                        output, = model(r_image[:, :, :, start:start + 384], boxes, num_boxes)
+                        output = output.squeeze(0)
+                        b1 = nn.ZeroPad2d(padding=(start, w - prev - 1, 0, 0))
+                        d1 = b1(output[:, 0:prev - start + 1])
+                        b2 = nn.ZeroPad2d(padding=(prev + 1, w - start - 384, 0, 0))
+                        d2 = b2(output[:, prev - start + 1:384])
 
-                        density_map = density_map_l + density_map_r + density_map_m/2 + d1/2 +d2
+                        b3 = nn.ZeroPad2d(padding=(0, w - start, 0, 0))
+                        density_map_l = b3(density_map[:, 0:start])
+                        density_map_m = b1(density_map[:, start:prev + 1])
+                        b4 = nn.ZeroPad2d(padding=(prev + 1, 0, 0, 0))
+                        density_map_r = b4(density_map[:, prev + 1:w])
+
+                        density_map = density_map_l + density_map_r + density_map_m / 2 + d1 / 2 + d2
 
                         prev = start + 383
                         start = start + 128
-                        if start+383 >= w:
-                            if start == w - 384 + 128: break
-                            else: start = w - 384
-                
-                pred_cnt += torch.sum(density_map/60).item()
-        else: 
-            density_map = torch.zeros([h,w])
+                        if start + 383 >= w:
+                            if start == w - 384 + 128:
+                                break
+                            else:
+                                start = w - 384
+
+                pred_cnt += torch.sum(density_map / 60).item()
+                r_densities += [density_map]
+        else:
+            density_map = torch.zeros([h, w])
             density_map = density_map.to(device, non_blocking=True)
             start = 0
             prev = -1
             with torch.no_grad():
                 while start + 383 < w:
-                    output, = model(samples[:,:,:,start:start+384], boxes, 3)
-                    output=output.squeeze(0)
-                    b1 = nn.ZeroPad2d(padding=(start, w-prev-1, 0, 0))
-                    d1 = b1(output[:,0:prev-start+1])
-                    b2 = nn.ZeroPad2d(padding=(prev+1, w-start-384, 0, 0))
-                    d2 = b2(output[:,prev-start+1:384])            
-                    
-                    b3 = nn.ZeroPad2d(padding=(0, w-start, 0, 0))
-                    density_map_l = b3(density_map[:,0:start])
-                    density_map_m = b1(density_map[:,start:prev+1])
-                    b4 = nn.ZeroPad2d(padding=(prev+1, 0, 0, 0))
-                    density_map_r = b4(density_map[:,prev+1:w])
+                    output, = model(samples[:, :, :, start:start + 384], boxes, num_boxes)
+                    output = output.squeeze(0)
+                    b1 = nn.ZeroPad2d(padding=(start, w - prev - 1, 0, 0))
+                    d1 = b1(output[:, 0:prev - start + 1])
+                    b2 = nn.ZeroPad2d(padding=(prev + 1, w - start - 384, 0, 0))
+                    d2 = b2(output[:, prev - start + 1:384])
 
-                    density_map = density_map_l + density_map_r + density_map_m/2 + d1/2 +d2
+                    b3 = nn.ZeroPad2d(padding=(0, w - start, 0, 0))
+                    density_map_l = b3(density_map[:, 0:start])
+                    density_map_m = b1(density_map[:, start:prev + 1])
+                    b4 = nn.ZeroPad2d(padding=(prev + 1, 0, 0, 0))
+                    density_map_r = b4(density_map[:, prev + 1:w])
+
+                    density_map = density_map_l + density_map_r + density_map_m / 2 + d1 / 2 + d2
 
                     prev = start + 383
                     start = start + 128
-                    if start+383 >= w:
-                        if start == w - 384 + 128: break
-                        else: start = w - 384
-            
-            pred_cnt = torch.sum(density_map/60).item()
+                    if start + 383 >= w:
+                        if start == w - 384 + 128:
+                            break
+                        else:
+                            start = w - 384
 
+            pred_cnt = torch.sum(density_map / 60).item()
+
+        if args.normalization:
             e_cnt = 0
-            cnt = 0
             for rect in pos:
-                cnt+=1
-                if cnt>3:
-                    break
-                e_cnt += torch.sum(density_map[rect[0]:rect[2]+1,rect[1]:rect[3]+1]/60).item()
+                e_cnt += torch.sum(density_map[rect[0]:rect[2] + 1, rect[1]:rect[3] + 1] / 60).item()
             e_cnt = e_cnt / 3
             if e_cnt > 1.8:
                 pred_cnt /= e_cnt
-        
+
         gt_cnt = gt_dots.shape[1]
         cnt_err = abs(pred_cnt - gt_cnt)
         train_mae += cnt_err
         train_rmse += cnt_err ** 2
 
-        print(f'{data_iter_step}/{len(data_loader_test)}: pred_cnt: {pred_cnt},  gt_cnt: {gt_cnt},  error: {cnt_err},  AE: {cnt_err},  SE: {cnt_err ** 2} ')
+        print(f'{data_iter_step}/{len(data_loader_test)}: pred_cnt: {pred_cnt},  gt_cnt: {gt_cnt},  error: {cnt_err},  AE: {cnt_err},  SE: {cnt_err ** 2}, id: {im_name.name}, s_cnt: {s_cnt >= 1}')
 
         loss_array.append(cnt_err)
         gt_array.append(gt_cnt)
-        
+        pred_arr.append(round(pred_cnt))
+        name_arr.append(im_name.name)
+
+        # compute and save images
+        fig = samples[0]
+        box_map = torch.zeros([fig.shape[1], fig.shape[2]], device=device)
+        if args.external is False:
+            for rect in pos:
+                for i in range(rect[2] - rect[0]):
+                    box_map[min(rect[0] + i, fig.shape[1] - 1), min(rect[1], fig.shape[2] - 1)] = 10
+                    box_map[min(rect[0] + i, fig.shape[1] - 1), min(rect[3], fig.shape[2] - 1)] = 10
+                for i in range(rect[3] - rect[1]):
+                    box_map[min(rect[0], fig.shape[1] - 1), min(rect[1] + i, fig.shape[2] - 1)] = 10
+                    box_map[min(rect[2], fig.shape[1] - 1), min(rect[1] + i, fig.shape[2] - 1)] = 10
+            box_map = box_map.unsqueeze(0).repeat(3, 1, 1)
+        pred = density_map.unsqueeze(0) if s_cnt < 1 else misc.make_grid(r_densities, h, w).unsqueeze(0)
+        pred = torch.cat((pred, torch.zeros_like(pred), torch.zeros_like(pred))) * 5
+        fig = fig + pred + box_map
+        fig = torch.clamp(fig, 0, 1)
+
+        pred_img = Image.new(mode="RGB", size=(w, h), color=(0, 0, 0))
+        draw = ImageDraw.Draw(pred_img)
+        draw.text((w-50, h-50), str(round(pred_cnt)), (255, 255, 255))
+        pred_img = np.array(pred_img).transpose((2, 0, 1))
+        pred_img = torch.tensor(np.array(pred_img), device=device) + pred
+        full = torch.cat((samples[0], fig, pred_img), -1)
+        torchvision.utils.save_image(full, (os.path.join(args.output_dir, f'full_{im_name.stem}__{round(pred_cnt)}{im_name.suffix}')))
+
         torch.cuda.synchronize()
 
     metric_logger.synchronize_between_processes()
     print("Averaged stats:", metric_logger)
-    
-    log_stats = {'MAE': train_mae/(len(data_loader_test)),
-                'RMSE':  (train_rmse/(len(data_loader_test)))**0.5}
 
-    print('Current MAE: {:5.2f}, RMSE: {:5.2f} '.format( train_mae/(len(data_loader_test)), (train_rmse/(len(data_loader_test)))**0.5))
+    log_stats = {'MAE': train_mae / (len(data_loader_test)),
+                 'RMSE': (train_rmse / (len(data_loader_test))) ** 0.5}
+
+    print('Current MAE: {:5.2f}, RMSE: {:5.2f} '.format(train_mae / (len(data_loader_test)), (
+                train_rmse / (len(data_loader_test))) ** 0.5))
 
     if args.output_dir and misc.is_main_process():
         with open(os.path.join(args.output_dir, "log.txt"), mode="a", encoding="utf-8") as f:
@@ -369,16 +440,32 @@ def main(args):
     plt.scatter(gt_array, loss_array)
     plt.xlabel('Ground Truth')
     plt.ylabel('Error')
-    plt.savefig(f'./Image/test_stat.png')
-    plt.show()
+    plt.savefig(os.path.join(args.output_dir, 'test_stat.png'))
+
+    df = pd.DataFrame(data={'time': np.arange(data_iter_step+1)+1, 'name': name_arr, 'prediction': pred_arr})
+    df.to_csv(os.path.join(args.output_dir, f'results.csv'), index=False)
 
     total_time = time.time() - start_time
     total_time_str = str(datetime.timedelta(seconds=int(total_time)))
     print('Testing time {}'.format(total_time_str))
 
+
 if __name__ == '__main__':
     args = get_args_parser()
     args = args.parse_args()
+
+    # load data
+    data_path = Path(args.data_path)
+    anno_file = data_path / args.anno_file
+    data_split_file = data_path / args.data_split_file
+    im_dir = data_path / args.im_dir
+
+    with open(anno_file) as f:
+        annotations = json.load(f)
+
+    with open(data_split_file) as f:
+        data_split = json.load(f)
+
     if args.output_dir:
         Path(args.output_dir).mkdir(parents=True, exist_ok=True)
     main(args)

--- a/FSC_test_cross(zero-shot).py
+++ b/FSC_test_cross(zero-shot).py
@@ -5,9 +5,10 @@ import numpy as np
 import os
 import time
 from pathlib import Path
-from PIL import Image
+from PIL import Image, ImageDraw
 import matplotlib.pyplot as plt
 import scipy.ndimage as ndimage
+import pandas as pd
 
 import torch
 import torch.nn as nn
@@ -16,10 +17,9 @@ from torch.utils.data import Dataset
 import torchvision
 from torchvision import transforms
 import torchvision.transforms.functional as TF
-
 import timm
 
-assert timm.__version__ == "0.3.2"  # version check
+assert "0.4.5" <= timm.__version__ <= "0.4.9"  # version check
 
 import util.misc as misc
 import models_mae_cross
@@ -61,7 +61,12 @@ def get_args_parser():
     # Dataset parameters
     parser.add_argument('--data_path', default='/GPFS/data/changliu/FSC147/', type=str,
                         help='dataset path')
-
+    parser.add_argument('--anno_file', default='annotation_FSC147_384.json', type=str,
+                        help='annotation json file')
+    parser.add_argument('--data_split_file', default='Train_Test_Val_FSC_147.json', type=str,
+                        help='data split json file')
+    parser.add_argument('--im_dir', default='images_384_VarV2', type=str,
+                        help='images directory')
     parser.add_argument('--output_dir', default='./Image',
                         help='path where to save, empty for no saving')
     parser.add_argument('--log_dir', default='./Image',
@@ -90,24 +95,13 @@ def get_args_parser():
 
     return parser
 
+
 os.environ["CUDA_LAUNCH_BLOCKING"] = '1'
 
-# load data from FSC147
-data_path = '/GPFS/data/changliu/FSC147/'
-anno_file = data_path + 'annotation_FSC147_384.json'
-data_split_file = data_path + 'Train_Test_Val_FSC_147.json'
-im_dir = data_path + 'images_384_VarV2'
-gt_dir = data_path + 'gt_density_map_adaptive_384_VarV2'
-
-with open(anno_file) as f:
-    annotations = json.load(f)
-
-with open(data_split_file) as f:
-    data_split = json.load(f)
 
 class TestData(Dataset):
     def __init__(self):
-        
+
         self.img = data_split['test']
         self.img_dir = im_dir
 
@@ -122,33 +116,33 @@ class TestData(Dataset):
         dots = np.array(anno['points'])
 
         image = Image.open('{}/{}'.format(im_dir, im_id))
-        image.load() 
+        image.load()
         W, H = image.size
 
-        new_H = 16*int(H/16)
-        new_W = 16*int(W/16)
-        scale_factor = float(new_W)/ W
+        new_H = 384
+        new_W = 16 * int((W / H * 384) / 16)
+        scale_factor = float(new_W) / W
         image = transforms.Resize((new_H, new_W))(image)
         Normalize = transforms.Compose([transforms.ToTensor()])
         image = Normalize(image)
 
         rects = list()
         for bbox in bboxes:
-            x1 = int(bbox[0][0]*scale_factor)
+            x1 = int(bbox[0][0] * scale_factor)
             y1 = bbox[0][1]
-            x2 = int(bbox[2][0]*scale_factor)
+            x2 = int(bbox[2][0] * scale_factor)
             y2 = bbox[2][1]
             rects.append([y1, x1, y2, x2])
 
         boxes = list()
         cnt = 0
         for box in rects:
-            cnt+=1
-            if cnt>3:
+            cnt += 1
+            if cnt > 3:
                 break
             box2 = [int(k) for k in box]
             y1, x1, y2, x2 = box2[0], box2[1], box2[2], box2[3]
-            bbox = image[:,y1:y2+1,x1:x2+1]
+            bbox = image[:, y1:y2 + 1, x1:x2 + 1]
             bbox = transforms.Resize((64, 64))(bbox)
             boxes.append(bbox.numpy())
 
@@ -156,15 +150,15 @@ class TestData(Dataset):
         boxes = torch.Tensor(boxes)
 
         # Only for visualisation purpose, no need for ground truth density map indeed.
-        gt_map = np.zeros((image.shape[1], image.shape[2]),dtype='float32')
+        gt_map = np.zeros((image.shape[1], image.shape[2]), dtype='float32')
         for i in range(dots.shape[0]):
-            gt_map[min(new_H-1,int(dots[i][1]))][min(new_W-1,int(dots[i][0]*scale_factor))]=1
+            gt_map[min(new_H - 1, int(dots[i][1]))][min(new_W - 1, int(dots[i][0] * scale_factor))] = 1
         gt_map = ndimage.gaussian_filter(gt_map, sigma=(1, 1), order=0)
         gt_map = torch.from_numpy(gt_map)
-        gt_map = gt_map *60
-        
-        sample = {'image':image,'dots':dots, 'boxes':boxes, 'pos':rects, 'gt_map':gt_map}
-        return sample['image'], sample['dots'], sample['boxes'], sample['pos'] ,sample['gt_map']
+        gt_map = gt_map * 60
+
+        sample = {'image': image, 'dots': dots, 'boxes': boxes, 'pos': rects, 'gt_map': gt_map, 'name': im_id}
+        return sample['image'], sample['dots'], sample['boxes'], sample['pos'], sample['gt_map'], sample['name']
 
 
 def main(args):
@@ -202,7 +196,7 @@ def main(args):
         pin_memory=args.pin_mem,
         drop_last=False,
     )
-    
+
     # define the model
     model = models_mae_cross.__dict__[args.model](norm_pix_loss=args.norm_pix_loss)
 
@@ -220,7 +214,7 @@ def main(args):
 
     print(f"Start testing.")
     start_time = time.time()
-    
+
     # test
     epoch = 0
     model.eval()
@@ -236,131 +230,153 @@ def main(args):
 
     loss_array = []
     gt_array = []
-    
-    for data_iter_step, (samples, gt_dots, boxes, pos, gt_map) in enumerate(metric_logger.log_every(data_loader_test, print_freq, header)):
+    pred_arr = []
+    name_arr = []
+
+    for data_iter_step, (samples, gt_dots, boxes, pos, gt_map, im_name) in \
+            enumerate(metric_logger.log_every(data_loader_test, print_freq, header)):
 
         samples = samples.to(device, non_blocking=True)
         gt_dots = gt_dots.to(device, non_blocking=True).half()
         boxes = boxes.to(device, non_blocking=True)
         pos = pos
-        gt_map = gt_map.to(device, non_blocking=True)
-        
-        _,_,h,w = samples.shape 
+
+        _, _, h, w = samples.shape
 
         r_cnt = 0
         s_cnt = 0
         for rect in pos:
-            r_cnt+=1
-            if r_cnt>3:
+            r_cnt += 1
+            if r_cnt > 3:
                 break
-            if rect[2]-rect[0]<10 and rect[3] - rect[1]<10:
-                s_cnt +=1
-        
-        if s_cnt >=100:
-            r_images = []
-            r_images.append(TF.crop(samples[0], 0, 0, int(h/3), int(w/3)))
-            r_images.append(TF.crop(samples[0], int(h/3), 0, int(h/3), int(w/3)))
-            r_images.append(TF.crop(samples[0], 0, int(w/3), int(h/3), int(w/3)))
-            r_images.append(TF.crop(samples[0], int(h/3), int(w/3), int(h/3), int(w/3)))
-            r_images.append(TF.crop(samples[0], int(h*2/3), 0, int(h/3), int(w/3)))
-            r_images.append(TF.crop(samples[0], int(h*2/3), int(w/3), int(h/3), int(w/3)))
-            r_images.append(TF.crop(samples[0], 0, int(w*2/3), int(h/3), int(w/3)))
-            r_images.append(TF.crop(samples[0], int(h/3), int(w*2/3), int(h/3), int(w/3)))
-            r_images.append(TF.crop(samples[0], int(h*2/3), int(w*2/3), int(h/3), int(w/3)))
+            if rect[2] - rect[0] < 10 and rect[3] - rect[1] < 10:
+                s_cnt += 1
 
+        if s_cnt >= 100:
+            r_images = []
+            r_images.append(TF.crop(samples[0], 0, 0, int(h / 3), int(w / 3)))
+            r_images.append(TF.crop(samples[0], int(h / 3), 0, int(h / 3), int(w / 3)))
+            r_images.append(TF.crop(samples[0], 0, int(w / 3), int(h / 3), int(w / 3)))
+            r_images.append(TF.crop(samples[0], int(h / 3), int(w / 3), int(h / 3), int(w / 3)))
+            r_images.append(TF.crop(samples[0], int(h * 2 / 3), 0, int(h / 3), int(w / 3)))
+            r_images.append(TF.crop(samples[0], int(h * 2 / 3), int(w / 3), int(h / 3), int(w / 3)))
+            r_images.append(TF.crop(samples[0], 0, int(w * 2 / 3), int(h / 3), int(w / 3)))
+            r_images.append(TF.crop(samples[0], int(h / 3), int(w * 2 / 3), int(h / 3), int(w / 3)))
+            r_images.append(TF.crop(samples[0], int(h * 2 / 3), int(w * 2 / 3), int(h / 3), int(w / 3)))
 
             pred_cnt = 0
             for r_image in r_images:
                 r_image = transforms.Resize((h, w))(r_image).unsqueeze(0)
-                density_map = torch.zeros([h,w])
+                density_map = torch.zeros([h, w])
                 density_map = density_map.to(device, non_blocking=True)
                 start = 0
                 prev = -1
-                
+
                 with torch.no_grad():
                     while start + 383 < w:
-                        output, = model(r_image[:,:,:,start:start+384], boxes, 3)
-                        output=output.squeeze(0)
-                        b1 = nn.ZeroPad2d(padding=(start, w-prev-1, 0, 0))
-                        d1 = b1(output[:,0:prev-start+1])
-                        b2 = nn.ZeroPad2d(padding=(prev+1, w-start-384, 0, 0))
-                        d2 = b2(output[:,prev-start+1:384])            
-                        
-                        b3 = nn.ZeroPad2d(padding=(0, w-start, 0, 0))
-                        density_map_l = b3(density_map[:,0:start])
-                        density_map_m = b1(density_map[:,start:prev+1])
-                        b4 = nn.ZeroPad2d(padding=(prev+1, 0, 0, 0))
-                        density_map_r = b4(density_map[:,prev+1:w])
+                        output, = model(r_image[:, :, :, start:start + 384], boxes, 3)
+                        output = output.squeeze(0)
+                        b1 = nn.ZeroPad2d(padding=(start, w - prev - 1, 0, 0))
+                        d1 = b1(output[:, 0:prev - start + 1])
+                        b2 = nn.ZeroPad2d(padding=(prev + 1, w - start - 384, 0, 0))
+                        d2 = b2(output[:, prev - start + 1:384])
 
-                        density_map = density_map_l + density_map_r + density_map_m/2 + d1/2 +d2
+                        b3 = nn.ZeroPad2d(padding=(0, w - start, 0, 0))
+                        density_map_l = b3(density_map[:, 0:start])
+                        density_map_m = b1(density_map[:, start:prev + 1])
+                        b4 = nn.ZeroPad2d(padding=(prev + 1, 0, 0, 0))
+                        density_map_r = b4(density_map[:, prev + 1:w])
+
+                        density_map = density_map_l + density_map_r + density_map_m / 2 + d1 / 2 + d2
 
                         prev = start + 383
                         start = start + 128
-                        if start+383 >= w:
-                            if start == w - 384 + 128: break
-                            else: start = w - 384
-                
-                pred_cnt += torch.sum(density_map/60).item()
-        else: 
-            density_map = torch.zeros([h,w])
+                        if start + 383 >= w:
+                            if start == w - 384 + 128:
+                                break
+                            else:
+                                start = w - 384
+
+                pred_cnt += torch.sum(density_map / 60).item()
+        else:
+            density_map = torch.zeros([h, w])
             density_map = density_map.to(device, non_blocking=True)
             start = 0
             prev = -1
             with torch.no_grad():
                 while start + 383 < w:
-                    output, = model(samples[:,:,:,start:start+384], boxes, 0)
-                    output=output.squeeze(0)
-                    b1 = nn.ZeroPad2d(padding=(start, w-prev-1, 0, 0))
-                    d1 = b1(output[:,0:prev-start+1])
-                    b2 = nn.ZeroPad2d(padding=(prev+1, w-start-384, 0, 0))
-                    d2 = b2(output[:,prev-start+1:384])            
-                    
-                    b3 = nn.ZeroPad2d(padding=(0, w-start, 0, 0))
-                    density_map_l = b3(density_map[:,0:start])
-                    density_map_m = b1(density_map[:,start:prev+1])
-                    b4 = nn.ZeroPad2d(padding=(prev+1, 0, 0, 0))
-                    density_map_r = b4(density_map[:,prev+1:w])
+                    output, = model(samples[:, :, :, start:start + 384], boxes, 0)
+                    output = output.squeeze(0)
+                    b1 = nn.ZeroPad2d(padding=(start, w - prev - 1, 0, 0))
+                    d1 = b1(output[:, 0:prev - start + 1])
+                    b2 = nn.ZeroPad2d(padding=(prev + 1, w - start - 384, 0, 0))
+                    d2 = b2(output[:, prev - start + 1:384])
 
-                    density_map = density_map_l + density_map_r + density_map_m/2 + d1/2 +d2
+                    b3 = nn.ZeroPad2d(padding=(0, w - start, 0, 0))
+                    density_map_l = b3(density_map[:, 0:start])
+                    density_map_m = b1(density_map[:, start:prev + 1])
+                    b4 = nn.ZeroPad2d(padding=(prev + 1, 0, 0, 0))
+                    density_map_r = b4(density_map[:, prev + 1:w])
+
+                    density_map = density_map_l + density_map_r + density_map_m / 2 + d1 / 2 + d2
 
                     prev = start + 383
                     start = start + 128
-                    if start+383 >= w:
-                        if start == w - 384 + 128: break
-                        else: start = w - 384
-            
-            pred_cnt = torch.sum(density_map/60).item()
+                    if start + 383 >= w:
+                        if start == w - 384 + 128:
+                            break
+                        else:
+                            start = w - 384
+
+            pred_cnt = torch.sum(density_map / 60).item()
 
             e_cnt = 0
             cnt = 0
             for rect in pos:
-                cnt+=1
-                if cnt>3:
+                cnt += 1
+                if cnt > 3:
                     break
-                e_cnt += torch.sum(density_map[rect[0]:rect[2]+1,rect[1]:rect[3]+1]/60).item()
-            e_cnt = e_cnt / 3
-            '''if e_cnt > 1.8:
-                pred_cnt /= e_cnt'''
-        
+                e_cnt += torch.sum(density_map[rect[0]:rect[2] + 1, rect[1]:rect[3] + 1] / 60).item()
+
         gt_cnt = gt_dots.shape[1]
         cnt_err = abs(pred_cnt - gt_cnt)
         train_mae += cnt_err
         train_rmse += cnt_err ** 2
 
-        print(f'{data_iter_step}/{len(data_loader_test)}: pred_cnt: {pred_cnt},  gt_cnt: {gt_cnt},  error: {cnt_err},  AE: {cnt_err},  SE: {cnt_err ** 2} ')
+        print(f'{data_iter_step}/{len(data_loader_test)}: pred_cnt: {pred_cnt},  gt_cnt: {gt_cnt},  error: {cnt_err},  AE: {cnt_err},  SE: {cnt_err ** 2}, id: {im_name[0]}')
 
         loss_array.append(cnt_err)
         gt_array.append(gt_cnt)
-        
+        pred_arr.append(round(pred_cnt))
+        name_arr.append(im_name[0])
+
+        # compute and save images
+        pred = density_map.unsqueeze(0)
+        pred = torch.cat((pred, torch.zeros_like(pred), torch.zeros_like(pred)))
+        fig = samples[0] + pred / 2
+        fig = torch.clamp(fig, 0, 1)
+
+        pred_img = Image.new(mode="RGB", size=(w, h), color=(0, 0, 0))
+        draw = ImageDraw.Draw(pred_img)
+        draw.text((w-50, h-50), str(round(pred_cnt)), (255, 255, 255))
+        pred_img = np.array(pred_img).transpose((2, 0, 1))
+        pred_img = torch.tensor(np.array(pred_img), device=device) + pred
+        full = torch.cat((samples[0], fig, pred_img), -1)
+
+        torchvision.utils.save_image(fig, (os.path.join(args.output_dir, f'vis_{im_name[0]}')))
+        torchvision.utils.save_image(pred_img, (os.path.join(args.output_dir, f'pred_{im_name[0]}')))
+        torchvision.utils.save_image(full, (os.path.join(args.output_dir, f'full_{im_name[0]}')))
+
         torch.cuda.synchronize()
 
     metric_logger.synchronize_between_processes()
     print("Averaged stats:", metric_logger)
-    
-    log_stats = {'MAE': train_mae/(len(data_loader_test)),
-                'RMSE':  (train_rmse/(len(data_loader_test)))**0.5}
 
-    print('Current MAE: {:5.2f}, RMSE: {:5.2f} '.format( train_mae/(len(data_loader_test)), (train_rmse/(len(data_loader_test)))**0.5))
+    log_stats = {'MAE': train_mae / (len(data_loader_test)),
+                 'RMSE': (train_rmse / (len(data_loader_test))) ** 0.5}
+
+    print('Current MAE: {:5.2f}, RMSE: {:5.2f} '.format(train_mae / (len(data_loader_test)), (
+                train_rmse / (len(data_loader_test))) ** 0.5))
 
     if args.output_dir and misc.is_main_process():
         with open(os.path.join(args.output_dir, "log.txt"), mode="a", encoding="utf-8") as f:
@@ -369,16 +385,32 @@ def main(args):
     plt.scatter(gt_array, loss_array)
     plt.xlabel('Ground Truth')
     plt.ylabel('Error')
-    plt.savefig(f'./Image/test_stat.png')
-    plt.show()
+    plt.savefig(os.path.join(args.output_dir, 'test_stat.png'))
+
+    df = pd.DataFrame(data={'time': np.arange(data_iter_step+1)+1, 'name': name_arr, 'prediction': pred_arr})
+    df.to_csv(os.path.join(args.output_dir, f'results.csv'), index=False)
 
     total_time = time.time() - start_time
     total_time_str = str(datetime.timedelta(seconds=int(total_time)))
     print('Testing time {}'.format(total_time_str))
 
+
 if __name__ == '__main__':
     args = get_args_parser()
     args = args.parse_args()
+
+    # load data
+    data_path = Path(args.data_path)
+    anno_file = data_path / args.anno_file
+    data_split_file = data_path / args.data_split_file
+    im_dir = data_path / args.im_dir
+
+    with open(anno_file) as f:
+        annotations = json.load(f)
+
+    with open(data_split_file) as f:
+        data_split = json.load(f)
+
     if args.output_dir:
         Path(args.output_dir).mkdir(parents=True, exist_ok=True)
     main(args)

--- a/demo.py
+++ b/demo.py
@@ -1,3 +1,4 @@
+import time
 import numpy as np
 from PIL import Image
 
@@ -9,47 +10,60 @@ import torchvision.transforms.functional as TF
 
 import timm
 
-assert timm.__version__ == "0.3.2"  # version check
+assert "0.4.5" <= timm.__version__ <= "0.4.9"  # version check
 
-import util.misc as misc
+from util.misc import make_grid
 import models_mae_cross
 
 device = torch.device('cuda')
+
+"""
+python demo.py
+"""
+
+
+class measure_time(object):
+    def __enter__(self):
+        self.start = time.perf_counter_ns()
+        return self
+
+    def __exit__(self, typ, value, traceback):
+        self.duration = (time.perf_counter_ns() - self.start) / 1e9
+
 
 def load_image():
     im_dir = '/GPFS/data/changliu/Dataset/FSC147/images_384_VarV2'
     im_id = '222.jpg'
 
     image = Image.open('{}/{}'.format(im_dir, im_id))
-    image.load() 
+    image.load()
     W, H = image.size
 
     # Resize the image size so that the height is 384
     new_H = 384
-    new_W = 16*int((W/H*384)/16)
-    scale_factor_H = float(new_H)/ H
-    scale_factor_W = float(new_W)/ W
+    new_W = 16 * int((W / H * 384) / 16)
+    scale_factor_H = float(new_H) / H
+    scale_factor_W = float(new_W) / W
     image = transforms.Resize((new_H, new_W))(image)
     Normalize = transforms.Compose([transforms.ToTensor()])
     image = Normalize(image)
 
-    
     # Coordinates of the exemplar bound boxes
     # The left upper corner and the right lower corner
-    bboxes = [   
-                [[136,98],[173,127]],
-                [[209,125],[242,150]],
-                [[212,168],[258,200]]
+    bboxes = [
+        [[136, 98], [173, 127]],
+        [[209, 125], [242, 150]],
+        [[212, 168], [258, 200]]
     ]
     boxes = list()
     rects = list()
     for bbox in bboxes:
-        x1 = int(bbox[0][0]*scale_factor_W)
-        y1 = int(bbox[0][1]*scale_factor_H)
-        x2 = int(bbox[1][0]*scale_factor_W)
-        y2 = int(bbox[1][1]*scale_factor_H)
+        x1 = int(bbox[0][0] * scale_factor_W)
+        y1 = int(bbox[0][1] * scale_factor_H)
+        x2 = int(bbox[1][0] * scale_factor_W)
+        y2 = int(bbox[1][1] * scale_factor_H)
         rects.append([y1, x1, y2, x2])
-        bbox = image[:,y1:y2+1,x1:x2+1]
+        bbox = image[:, y1:y2 + 1, x1:x2 + 1]
         bbox = transforms.Resize((64, 64))(bbox)
         boxes.append(bbox.numpy())
 
@@ -58,112 +72,122 @@ def load_image():
 
     return image, boxes, rects
 
+
 def run_one_image(samples, boxes, pos, model):
-    _,_,h,w = samples.shape
-    
+    _, _, h, w = samples.shape
+
     s_cnt = 0
     for rect in pos:
-        if rect[2]-rect[0]<10 and rect[3] - rect[1]<10:
-            s_cnt +=1
-    if s_cnt >=1:
+        if rect[2] - rect[0] < 10 and rect[3] - rect[1] < 10:
+            s_cnt += 1
+    if s_cnt >= 1:
+        r_densities = []
         r_images = []
-        r_images.append(TF.crop(samples[0], 0, 0, int(h/3), int(w/3)))
-        r_images.append(TF.crop(samples[0], int(h/3), 0, int(h/3), int(w/3)))
-        r_images.append(TF.crop(samples[0], 0, int(w/3), int(h/3), int(w/3)))
-        r_images.append(TF.crop(samples[0], int(h/3), int(w/3), int(h/3), int(w/3)))
-        r_images.append(TF.crop(samples[0], int(h*2/3), 0, int(h/3), int(w/3)))
-        r_images.append(TF.crop(samples[0], int(h*2/3), int(w/3), int(h/3), int(w/3)))
-        r_images.append(TF.crop(samples[0], 0, int(w*2/3), int(h/3), int(w/3)))
-        r_images.append(TF.crop(samples[0], int(h/3), int(w*2/3), int(h/3), int(w/3)))
-        r_images.append(TF.crop(samples[0], int(h*2/3), int(w*2/3), int(h/3), int(w/3)))
-        
+        r_images.append(TF.crop(samples[0], 0, 0, int(h / 3), int(w / 3)))  # 1
+        r_images.append(TF.crop(samples[0], 0, int(w / 3), int(h / 3), int(w / 3)))  # 3
+        r_images.append(TF.crop(samples[0], 0, int(w * 2 / 3), int(h / 3), int(w / 3)))  # 7
+        r_images.append(TF.crop(samples[0], int(h / 3), 0, int(h / 3), int(w / 3)))  # 2
+        r_images.append(TF.crop(samples[0], int(h / 3), int(w / 3), int(h / 3), int(w / 3)))  # 4
+        r_images.append(TF.crop(samples[0], int(h / 3), int(w * 2 / 3), int(h / 3), int(w / 3)))  # 8
+        r_images.append(TF.crop(samples[0], int(h * 2 / 3), 0, int(h / 3), int(w / 3)))  # 5
+        r_images.append(TF.crop(samples[0], int(h * 2 / 3), int(w / 3), int(h / 3), int(w / 3)))  # 6
+        r_images.append(TF.crop(samples[0], int(h * 2 / 3), int(w * 2 / 3), int(h / 3), int(w / 3)))  # 9
+
         pred_cnt = 0
-        for r_image in r_images:
-            r_image = transforms.Resize((h, w))(r_image).unsqueeze(0)
-            density_map = torch.zeros([h,w])
-            density_map = density_map.to(device, non_blocking=True)
-            start = 0
-            prev = -1
-            with torch.no_grad():
-                while start + 383 < w:
-                    output, = model(r_image[:,:,:,start:start+384], boxes, 3)
-                    output=output.squeeze(0)
-                    b1 = nn.ZeroPad2d(padding=(start, w-prev-1, 0, 0))
-                    d1 = b1(output[:,0:prev-start+1])
-                    b2 = nn.ZeroPad2d(padding=(prev+1, w-start-384, 0, 0))
-                    d2 = b2(output[:,prev-start+1:384])            
-                    
-                    b3 = nn.ZeroPad2d(padding=(0, w-start, 0, 0))
-                    density_map_l = b3(density_map[:,0:start])
-                    density_map_m = b1(density_map[:,start:prev+1])
-                    b4 = nn.ZeroPad2d(padding=(prev+1, 0, 0, 0))
-                    density_map_r = b4(density_map[:,prev+1:w])
+        with measure_time() as et:
+            for r_image in r_images:
+                r_image = transforms.Resize((h, w))(r_image).unsqueeze(0)
+                density_map = torch.zeros([h, w])
+                density_map = density_map.to(device, non_blocking=True)
+                start = 0
+                prev = -1
+                with torch.no_grad():
+                    while start + 383 < w:
+                        output, = model(r_image[:, :, :, start:start + 384], boxes, 3)
+                        output = output.squeeze(0)
+                        b1 = nn.ZeroPad2d(padding=(start, w - prev - 1, 0, 0))
+                        d1 = b1(output[:, 0:prev - start + 1])
+                        b2 = nn.ZeroPad2d(padding=(prev + 1, w - start - 384, 0, 0))
+                        d2 = b2(output[:, prev - start + 1:384])
 
-                    density_map = density_map_l + density_map_r + density_map_m/2 + d1/2 +d2
+                        b3 = nn.ZeroPad2d(padding=(0, w - start, 0, 0))
+                        density_map_l = b3(density_map[:, 0:start])
+                        density_map_m = b1(density_map[:, start:prev + 1])
+                        b4 = nn.ZeroPad2d(padding=(prev + 1, 0, 0, 0))
+                        density_map_r = b4(density_map[:, prev + 1:w])
 
-                    prev = start + 383
-                    start = start + 128
-                    if start+383 >= w:
-                        if start == w - 384 + 128: break
-                        else: start = w - 384
-            
-            pred_cnt += torch.sum(density_map/60).item()
-    else: 
-        density_map = torch.zeros([h,w])
+                        density_map = density_map_l + density_map_r + density_map_m / 2 + d1 / 2 + d2
+
+                        prev = start + 383
+                        start = start + 128
+                        if start + 383 >= w:
+                            if start == w - 384 + 128:
+                                break
+                            else:
+                                start = w - 384
+
+                pred_cnt += torch.sum(density_map / 60).item()
+                r_densities += [density_map]
+    else:
+        density_map = torch.zeros([h, w])
         density_map = density_map.to(device, non_blocking=True)
         start = 0
         prev = -1
-        with torch.no_grad():
-            while start + 383 < w:
-                output, = model(samples[:,:,:,start:start+384], boxes, 3)
-                output=output.squeeze(0)
-                b1 = nn.ZeroPad2d(padding=(start, w-prev-1, 0, 0))
-                d1 = b1(output[:,0:prev-start+1])
-                b2 = nn.ZeroPad2d(padding=(prev+1, w-start-384, 0, 0))
-                d2 = b2(output[:,prev-start+1:384])            
-                
-                b3 = nn.ZeroPad2d(padding=(0, w-start, 0, 0))
-                density_map_l = b3(density_map[:,0:start])
-                density_map_m = b1(density_map[:,start:prev+1])
-                b4 = nn.ZeroPad2d(padding=(prev+1, 0, 0, 0))
-                density_map_r = b4(density_map[:,prev+1:w])
+        with measure_time() as et:
+            with torch.no_grad():
+                while start + 383 < w:
+                    output, = model(samples[:, :, :, start:start + 384], boxes, 3)
+                    output = output.squeeze(0)
+                    b1 = nn.ZeroPad2d(padding=(start, w - prev - 1, 0, 0))
+                    d1 = b1(output[:, 0:prev - start + 1])
+                    b2 = nn.ZeroPad2d(padding=(prev + 1, w - start - 384, 0, 0))
+                    d2 = b2(output[:, prev - start + 1:384])
 
-                density_map = density_map_l + density_map_r + density_map_m/2 + d1/2 +d2
+                    b3 = nn.ZeroPad2d(padding=(0, w - start, 0, 0))
+                    density_map_l = b3(density_map[:, 0:start])
+                    density_map_m = b1(density_map[:, start:prev + 1])
+                    b4 = nn.ZeroPad2d(padding=(prev + 1, 0, 0, 0))
+                    density_map_r = b4(density_map[:, prev + 1:w])
 
-                prev = start + 383
-                start = start + 128
-                if start+383 >= w:
-                    if start == w - 384 + 128: break
-                    else: start = w - 384
-        
-        pred_cnt = torch.sum(density_map/60).item()
+                    density_map = density_map_l + density_map_r + density_map_m / 2 + d1 / 2 + d2
 
-        e_cnt = 0
-        for rect in pos:
-            e_cnt += torch.sum(density_map[rect[0]:rect[2]+1,rect[1]:rect[3]+1]/60).item()
-        e_cnt = e_cnt / 3
-        if e_cnt > 1.8:
-            pred_cnt /= e_cnt
+                    prev = start + 383
+                    start = start + 128
+                    if start + 383 >= w:
+                        if start == w - 384 + 128:
+                            break
+                        else:
+                            start = w - 384
 
-        # Visualize the prediction
-        # If the example uses test-time cropping(if s_cnt >=1 branch), then the visualisation is meaningless.
-        fig = samples[0]
-        box_map = torch.zeros([fig.shape[1],fig.shape[2]])
-        box_map = box_map.to(device, non_blocking=True)
-        for rect in pos:      
-            for i in range(rect[2]-rect[0]):
-                box_map[min(rect[0]+i,fig.shape[1]-1),min(rect[1],fig.shape[2]-1)] = 10
-                box_map[min(rect[0]+i,fig.shape[1]-1),min(rect[3],fig.shape[2]-1)] = 10
-            for i in range(rect[3]-rect[1]):
-                box_map[min(rect[0],fig.shape[1]-1),min(rect[1]+i,fig.shape[2]-1)] = 10
-                box_map[min(rect[2],fig.shape[1]-1),min(rect[1]+i,fig.shape[2]-1)] = 10
-        box_map = box_map.unsqueeze(0).repeat(3,1,1) 
-        pred = density_map.unsqueeze(0).repeat(3,1,1)
-        fig = fig + box_map + pred/2
-        fig = torch.clamp(fig, 0, 1)
-        torchvision.utils.save_image(fig, f'./Image/Visualisation.png')
-        # GT map needs coordinates for all GT dots, which is hard to input and is not a must for the demo. You can provide it yourself.
-        return pred_cnt
+            pred_cnt = torch.sum(density_map / 60).item()
+
+    e_cnt = 0
+    for rect in pos:
+        e_cnt += torch.sum(density_map[rect[0]:rect[2] + 1, rect[1]:rect[3] + 1] / 60).item()
+    e_cnt = e_cnt / 3
+    if e_cnt > 1.8:
+        pred_cnt /= e_cnt
+
+    # Visualize the prediction
+    fig = samples[0]
+    box_map = torch.zeros([fig.shape[1], fig.shape[2]])
+    box_map = box_map.to(device, non_blocking=True)
+    for rect in pos:
+        for i in range(rect[2] - rect[0]):
+            box_map[min(rect[0] + i, fig.shape[1] - 1), min(rect[1], fig.shape[2] - 1)] = 10
+            box_map[min(rect[0] + i, fig.shape[1] - 1), min(rect[3], fig.shape[2] - 1)] = 10
+        for i in range(rect[3] - rect[1]):
+            box_map[min(rect[0], fig.shape[1] - 1), min(rect[1] + i, fig.shape[2] - 1)] = 10
+            box_map[min(rect[2], fig.shape[1] - 1), min(rect[1] + i, fig.shape[2] - 1)] = 10
+    box_map = box_map.unsqueeze(0).repeat(3, 1, 1)
+    pred = density_map.unsqueeze(0).repeat(3, 1, 1) if s_cnt < 1 \
+        else make_grid(r_densities, h, w).unsqueeze(0).repeat(3, 1, 1)
+    fig = fig + box_map + pred / 2
+    fig = torch.clamp(fig, 0, 1)
+    torchvision.utils.save_image(fig, f'./Image/Visualisation.png')
+    # GT map needs coordinates for all GT dots, which is hard to input and is not a must for the demo. You can provide it yourself.
+    return pred_cnt, et
+
 
 # Prepare model
 model = models_mae_cross.__dict__['mae_vit_base_patch16'](norm_pix_loss='store_true')
@@ -181,6 +205,5 @@ samples, boxes, pos = load_image()
 samples = samples.unsqueeze(0).to(device, non_blocking=True)
 boxes = boxes.unsqueeze(0).to(device, non_blocking=True)
 
-result = run_one_image(samples, boxes, pos, model)
-
-print(result)
+result, elapsed_time = run_one_image(samples, boxes, pos, model)
+print(result, elapsed_time.duration)

--- a/models_mae_cross.py
+++ b/models_mae_cross.py
@@ -1,10 +1,14 @@
+import time
 from functools import partial
 import math
+import random
+
 import numpy as np
 
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+import torchvision.utils
 
 from timm.models.vision_transformer import PatchEmbed, Block
 from models_crossvit import CrossAttentionBlock
@@ -194,6 +198,8 @@ class SupervisedMAE(nn.Module):
         return x
 
     def forward(self, imgs, boxes, shot_num):
+        # if boxes.nelement() > 0:
+        #     torchvision.utils.save_image(boxes[0], f"data/out/crops/box_{time.time()}_{random.randint(0, 99999):>5}.png")
         with torch.no_grad():
             latent = self.forward_encoder(imgs)
         pred = self.forward_decoder(latent, boxes, shot_num)  # [N, 384, 384]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+torchvision>=0.14.0
+timm~=0.4.9
+numpy>=1.23.4
+scipy>=1.9.3
+imgaug>=0.4.0
+pillow>=9.2.0
+matplotlib>=3.5.3
+hub>=3.0.1
+pandas>=1.5.1


### PR DESCRIPTION
Added:
- `requirements.txt` file;
- possibility to use **external exemplars** in `FSC_test_cross(few-shot).py` via the `--external` parameter: all the test images share the same exemplars, given in the standard annotations json file, but only for few input images;
- visualisation of **meaningful images even with small exemplars** (`s_cnt` >= 1) in `demo.py` and `FSC_test_cross(few-shot).py`;
- writing of **images with predictions and bounding boxes** (the latter only if not "external") for each test image in `FSC_test_cross(few-shot).py`;
- writing of a **plot with the number of counted objects** for each input image in `FSC_test_cross(zero-shot).py` (particularly useful when doing inference on video frames);
- parameters to define all the needed input files and directories (`anno_file`, `data_split_file`, `im_dir`);
- parametrized limit to the number of exemplars used for any test image in `FSC_test_cross(few-shot).py` via the `--box_bound` parameter;
- possibility to disable test-time normalization in `FSC_test_cross(few-shot).py` via the `--normalization` parameter;
- print of elapsed time in `demo.py`.