### PR TITLE
Updated training with WandB logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 !/data/letsea_14/annotations_few.json
 !/data/letsea_14/annotations_zero.json
 !/data/letsea_14/split.json
+/logs/
+/wandb/

--- a/FSC_pretrain.py
+++ b/FSC_pretrain.py
@@ -1,6 +1,8 @@
 import argparse
 import datetime
 import json
+
+import PIL.Image
 import numpy as np
 import os
 import time
@@ -13,20 +15,18 @@ from PIL import Image
 import torch
 import torch.backends.cudnn as cudnn
 from torch.utils.tensorboard import SummaryWriter
-import torchvision.transforms as transforms
+import torch.nn.functional as F
 from torch.utils.data import Dataset
-from torchvision.io import read_image
-import torchvision
-
+import wandb
 import timm
 
-assert timm.__version__ == "0.3.2"  # version check
+assert "0.4.5" <= timm.__version__ <= "0.4.9"  # version check
 import timm.optim.optim_factory as optim_factory
 
 import util.misc as misc
 from util.misc import NativeScalerWithGradNormCount as NativeScaler
 import util.lr_sched as lr_sched
-from util.FSC147 import TransformPreTrain
+from util.FSC147 import transform_pre_train
 import models_mae_noct
 
 
@@ -35,7 +35,7 @@ def get_args_parser():
     parser.add_argument('--batch_size', default=8, type=int,
                         help='Batch size per GPU (effective batch size is batch_size * accum_iter * # gpus')
     parser.add_argument('--epochs', default=200, type=int)
-    parser.add_argument('--accum_iter', default=8, type=int,
+    parser.add_argument('--accum_iter', default=1, type=int,
                         help='Accumulate gradient iterations (for increasing the effective batch size under memory constraints)')
 
     # Model parameters
@@ -52,31 +52,35 @@ def get_args_parser():
     # Optimizer parameters
     parser.add_argument('--weight_decay', type=float, default=0.05,
                         help='weight decay (default: 0.05)')
-
     parser.add_argument('--lr', type=float, default=None, metavar='LR',
                         help='learning rate (absolute lr)')
     parser.add_argument('--blr', type=float, default=1e-3, metavar='LR',
                         help='base learning rate: absolute_lr = base_lr * total_batch_size / 256')
     parser.add_argument('--min_lr', type=float, default=0., metavar='LR',
                         help='lower lr bound for cyclic schedulers that hit 0')
-
-    parser.add_argument('--warmup_epochs', type=int, default=40, metavar='N',
+    parser.add_argument('--warmup_epochs', type=int, default=10, metavar='N',
                         help='epochs to warmup LR')
 
     # Dataset parameters
-    parser.add_argument('--data_path', default='/GPFS/data/changliu/FSC147/', type=str,
+    parser.add_argument('--data_path', default='./data/FSC147/', type=str,
                         help='dataset path')
-
-    parser.add_argument('--output_dir', default='./output_pre_4_dir',
+    parser.add_argument('--anno_file', default='annotation_FSC147_384.json', type=str,
+                        help='annotation json file')
+    parser.add_argument('--data_split_file', default='Train_Test_Val_FSC_147.json', type=str,
+                        help='data split json file')
+    parser.add_argument('--im_dir', default='images_384_VarV2', type=str,
+                        help='images directory')
+    parser.add_argument('--gt_dir', default='gt_density_map_adaptive_384_VarV2', type=str,
+                        help='ground truth directory')
+    parser.add_argument('--output_dir', default='./data/out/pre_4_dir',
                         help='path where to save, empty for no saving')
-    parser.add_argument('--log_dir', default='./output_pre_4_dir',
-                        help='path where to tensorboard log')
     parser.add_argument('--device', default='cuda',
                         help='device to use for training / testing')
     parser.add_argument('--seed', default=0, type=int)
-    parser.add_argument('--resume', default='./checkpoint/mae_visualize_vit_base.pth',
+    parser.add_argument('--resume', default='./weights/mae_pretrain_vit_base_full.pth',  # mae_visualize_vit_base
                         help='resume from checkpoint')
 
+    # Training parameters
     parser.add_argument('--start_epoch', default=0, type=int, metavar='N',
                         help='start epoch')
     parser.add_argument('--num_workers', default=10, type=int)
@@ -85,7 +89,7 @@ def get_args_parser():
     parser.add_argument('--no_pin_mem', action='store_false', dest='pin_mem')
     parser.set_defaults(pin_mem=True)
 
-    # distributed training parameters
+    # Distributed training parameters
     parser.add_argument('--world_size', default=1, type=int,
                         help='number of distributed processes')
     parser.add_argument('--local_rank', default=-1, type=int)
@@ -93,29 +97,26 @@ def get_args_parser():
     parser.add_argument('--dist_url', default='env://',
                         help='url used to set up distributed training')
 
+    # Logging parameters
+    parser.add_argument('--log_dir', default='./logs/pre_4_dir',
+                        help='path where to tensorboard log')
+    parser.add_argument("--title", default="CounTR_pretraining", type=str)
+    parser.add_argument("--wandb", default="counting", type=str)
+    parser.add_argument("--team", default="wsense", type=str)
+    parser.add_argument("--wandb_id", default=None, type=str)
+
     return parser
+
 
 os.environ["CUDA_LAUNCH_BLOCKING"] = '1'
 
-# load data from FSC147
-data_path = '/GPFS/data/changliu/FSC147/'
-anno_file = data_path + 'annotation_FSC147_384.json'
-data_split_file = data_path + 'Train_Test_Val_FSC_147.json'
-im_dir = data_path + 'images_384_VarV2'
-gt_dir = data_path + 'gt_density_map_adaptive_384_VarV2'
-
-with open(anno_file) as f:
-    annotations = json.load(f)
-
-with open(data_split_file) as f:
-    data_split = json.load(f)
 
 class TrainData(Dataset):
     def __init__(self):
-        
         self.img = data_split['train']
         random.shuffle(self.img)
         self.img_dir = im_dir
+        self.TransformPreTrain = transform_pre_train(data_path)
 
     def __len__(self):
         return len(self.img)
@@ -124,7 +125,6 @@ class TrainData(Dataset):
         im_id = self.img[idx]
         anno = annotations[im_id]
         bboxes = anno['box_examples_coordinates']
-        #dots = np.array(anno['points'])
 
         rects = list()
         for bbox in bboxes:
@@ -136,10 +136,10 @@ class TrainData(Dataset):
 
         image = Image.open('{}/{}'.format(im_dir, im_id))
         image.load()
-        density_path = gt_dir + '/' + im_id.split(".jpg")[0] + ".npy"
-        density = np.load(density_path).astype('float32')    
-        sample = {'image':image,'lines_boxes':rects,'gt_density':density}
-        sample = TransformPreTrain(sample)
+        density_path = gt_dir / (im_id.split(".jpg")[0] + ".npy")
+        density = np.load(density_path).astype('float32')
+        sample = {'image': image, 'lines_boxes': rects, 'gt_density': density}
+        sample = self.TransformPreTrain(sample)
         return sample['image']
 
 
@@ -171,11 +171,24 @@ def main(args):
     else:
         sampler_train = torch.utils.data.RandomSampler(dataset_train)
 
-    if global_rank == 0 and args.log_dir is not None:
-        os.makedirs(args.log_dir, exist_ok=True)
-        log_writer = SummaryWriter(log_dir=args.log_dir)
-    else:
-        log_writer = None
+    if global_rank == 0:
+        if args.log_dir is not None:
+            os.makedirs(args.log_dir, exist_ok=True)
+            log_writer = SummaryWriter(log_dir=args.log_dir)
+        else:
+            log_writer = None
+        if args.wandb is not None:
+            wandb_run = wandb.init(
+                config=args,
+                resume="allow",
+                project=args.wandb,
+                name=args.title,
+                entity=args.team,
+                tags=["CounTR", "pretraining"],
+                id=args.wandb_id,
+            )
+        else:
+            wandb_run = None
 
     data_loader_train = torch.utils.data.DataLoader(
         dataset_train, sampler=sampler_train,
@@ -184,7 +197,7 @@ def main(args):
         pin_memory=args.pin_mem,
         drop_last=False,
     )
-    
+
     # define the model
     model = models_mae_noct.__dict__[args.model](norm_pix_loss=args.norm_pix_loss)
 
@@ -195,7 +208,7 @@ def main(args):
     print("Model = %s" % str(model_without_ddp))
 
     eff_batch_size = args.batch_size * args.accum_iter * misc.get_world_size()
-    
+
     if args.lr is None:  # only base_lr is specified
         args.lr = args.blr * eff_batch_size / 256
 
@@ -222,7 +235,7 @@ def main(args):
     for epoch in range(args.start_epoch, args.epochs):
         if args.distributed:
             data_loader_train.sampler.set_epoch(epoch)
-        
+
         # train one epoch
         model.train(True)
         metric_logger = misc.MetricLogger(delimiter="  ")
@@ -235,32 +248,47 @@ def main(args):
 
         if log_writer is not None:
             print('log_dir: {}'.format(log_writer.log_dir))
-        
-        model_ = getattr(models_mae_noct, 'mae_vit_base_patch16')()
+
+        model_ = getattr(models_mae_noct, args.model)()
 
         for data_iter_step, samples in enumerate(metric_logger.log_every(data_loader_train, print_freq, header)):
-
+            epoch_1000x = int((data_iter_step / len(data_loader_train) + epoch) * 1000)
 
             if data_iter_step % accum_iter == 0:
                 lr_sched.adjust_learning_rate(optimizer, data_iter_step / len(data_loader_train) + epoch, args)
 
-        
             samples = samples.to(device, non_blocking=True)
 
             with torch.cuda.amp.autocast():
-                loss, pred, _ = model(samples, mask_ratio=args.mask_ratio)
+                loss, pred, mask = model(samples, mask_ratio=args.mask_ratio)
 
             loss_value = loss.item()
 
-            if data_iter_step % 2000 ==0:
+            if data_iter_step % 2000 == 0:
                 preds = model_.unpatchify(pred)
                 preds = preds.float()
-                preds = torch.einsum('nchw->nhwc', preds).detach().cpu()
+                preds = torch.einsum('nchw->nhwc', preds)
                 preds = torch.clip(preds, 0, 1)
-                
-                if log_writer is not None:
-                    log_writer.add_images('reconstruction', preds, int(epoch),dataformats='NHWC')
 
+                if log_writer is not None:
+                    log_writer.add_images('reconstruction', preds, int(epoch), dataformats='NHWC')
+
+                if wandb_run is not None:
+                    wandb_images = []
+                    w_samples = torch.einsum('nchw->nhwc', samples.float()).clip(0, 1)
+                    masks = F.interpolate(
+                        mask.reshape(shape=(mask.shape[0], 1, int(mask.shape[1] ** .5), int(mask.shape[1] ** .5))),
+                        size=(preds.shape[1], preds.shape[2]))
+                    masks = torch.einsum('nchw->nhwc', masks.float())
+                    combos = (w_samples + masks.repeat(1, 1, 1, 3)).clip(0, 1)
+                    w_images = (torch.cat([w_samples, combos, preds], dim=2) * 255).detach().cpu()
+                    print("w_images:", w_samples.shape, combos.shape, preds.shape, "-->", w_images.shape)
+
+                    for i in range(w_images.shape[0]):
+                        wi = w_images[i, :, :, :]
+                        wandb_images += [wandb.Image(wi.numpy().astype(np.uint8),
+                                                     caption=f"Prediction {i} at epoch {epoch}")]
+                    wandb.log({f"reconstruction": wandb_images}, step=epoch_1000x, commit=False)
 
             if not math.isfinite(loss_value):
                 print("Loss is {}, stopping training".format(loss_value))
@@ -271,7 +299,7 @@ def main(args):
                         update_grad=(data_iter_step + 1) % accum_iter == 0)
             if (data_iter_step + 1) % accum_iter == 0:
                 optimizer.zero_grad()
-            
+
             torch.cuda.synchronize()
 
             metric_logger.update(loss=loss_value)
@@ -280,26 +308,28 @@ def main(args):
             metric_logger.update(lr=lr)
 
             loss_value_reduce = misc.all_reduce_mean(loss_value)
-            if log_writer is not None and (data_iter_step + 1) % accum_iter == 0:
-                """ We use epoch_1000x as the x-axis in tensorboard.
-                This calibrates different curves when batch size changes.
-                """
-                epoch_1000x = int((data_iter_step / len(data_loader_train) + epoch) * 1000)
-                log_writer.add_scalar('train_loss', loss_value_reduce, epoch_1000x)
-                log_writer.add_scalar('lr', lr, epoch_1000x)
+            if (data_iter_step + 1) % accum_iter == 0:
+                if log_writer is not None:
+                    """ We use epoch_1000x as the x-axis in tensorboard.
+                    This calibrates different curves when batch size changes.
+                    """
+                    log_writer.add_scalar('train_loss', loss_value_reduce, epoch_1000x)
+                    log_writer.add_scalar('lr', lr, epoch_1000x)
+                if wandb_run is not None:
+                    log = {"train/loss": loss_value_reduce, "train/lr": lr}
+                    wandb.log(log, step=epoch_1000x, commit=True if data_iter_step == 0 else False)
 
         metric_logger.synchronize_between_processes()
         print("Averaged stats:", metric_logger)
-        train_stats = {k: meter.global_avg for k, meter in metric_logger.meters.items()}    
-        
+        train_stats = {k: meter.global_avg for k, meter in metric_logger.meters.items()}
+
         # save train status and model
         if args.output_dir and (epoch % 100 == 0 or epoch + 1 == args.epochs):
-            misc.save_model(
-                args=args, model=model, model_without_ddp=model_without_ddp, optimizer=optimizer,
-                loss_scaler=loss_scaler, epoch=epoch)
+            misc.save_model(args=args, model=model, model_without_ddp=model_without_ddp, optimizer=optimizer,
+                            loss_scaler=loss_scaler, epoch=epoch, suffix=f"pretraining_{epoch}")
 
         log_stats = {**{f'train_{k}': v for k, v in train_stats.items()},
-                        'epoch': epoch,}
+                     'epoch': epoch, }
 
         if args.output_dir and misc.is_main_process():
             if log_writer is not None:
@@ -310,10 +340,24 @@ def main(args):
     total_time = time.time() - start_time
     total_time_str = str(datetime.timedelta(seconds=int(total_time)))
     print('Training time {}'.format(total_time_str))
+    wandb.run.finish()
+
 
 if __name__ == '__main__':
     args = get_args_parser()
     args = args.parse_args()
+
+    # load data
+    data_path = Path(args.data_path)
+    anno_file = data_path / args.anno_file
+    data_split_file = data_path / args.data_split_file
+    im_dir = data_path / args.im_dir
+    gt_dir = data_path / args.gt_dir
+    with open(anno_file) as f:
+        annotations = json.load(f)
+    with open(data_split_file) as f:
+        data_split = json.load(f)
+
     if args.output_dir:
         Path(args.output_dir).mkdir(parents=True, exist_ok=True)
     main(args)

--- a/models_mae_cross.py
+++ b/models_mae_cross.py
@@ -27,7 +27,7 @@ class SupervisedMAE(nn.Module):
         self.patch_embed = PatchEmbed(img_size, patch_size, in_chans, embed_dim)
         num_patches = self.patch_embed.num_patches
 
-        self.pos_embed = nn.Parameter(torch.zeros(1, num_patches , embed_dim), requires_grad=False)  # fixed sin-cos embedding
+        self.pos_embed = nn.Parameter(torch.zeros(1, num_patches, embed_dim), requires_grad=False)  # fixed sin-cos embedding
 
         self.blocks = nn.ModuleList([
             Block(embed_dim, num_heads, mlp_ratio, qkv_bias=True, qk_scale=None, norm_layer=norm_layer)
@@ -113,6 +113,7 @@ class SupervisedMAE(nn.Module):
         
         decoder_pos_embed = get_2d_sincos_pos_embed(self.decoder_pos_embed.shape[-1], int(self.patch_embed.num_patches**.5), cls_token=False)
         self.decoder_pos_embed.data.copy_(torch.from_numpy(decoder_pos_embed).float().unsqueeze(0))
+
         # initialize patch_embed like nn.Linear (instead of nn.Conv2d)
         w = self.patch_embed.proj.weight.data
         torch.nn.init.xavier_uniform_(w.view([w.shape[0], -1]))

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,20 @@
+set -e
+
+# *** reproduce results ***
+# see https://github.com/Verg-Avesta/CounTR/issues/23
+
+#python FSC_test_cross\(few-shot\).py --output_dir ./data/out/aaa --resume ./weights/FSC147.pth --box_bound 3
+
+
+# *** reproduce pre-training and fine-tuning described in the paper ***
+
+CUDA_VISIBLE_DEVICES=0 python FSC_pretrain.py --epochs 300 --batch_size 16 --lr 5e-6 --output_dir ./data/out/pretrain --log_dir None --title CounTR_pretraining_paper
+CUDA_VISIBLE_DEVICES=0 python FSC_finetune_cross.py --epochs 1000 --batch_size 8 --lr 1e-5 --output_dir ./data/out/finetune --log_dir None --title CounTR_finetuning_paper --resume ./data/out/pretrain/checkpoint__pretraining_299.pth
+python FSC_test_cross\(few-shot\).py --output_dir ./data/out/results_base --resume ./data/out/finetune/checkpoint__finetuning_minMAE.pth --box_bound 3
+
+
+# *** reproduce pre-training and fine-tuning described in the paper, using the large MAE model ***
+
+# CUDA_VISIBLE_DEVICES=0 python FSC_pretrain.py --epochs 300 --batch_size 16 --lr 5e-6 --output_dir ./data/out/pretrain_large --log_dir None --title CounTR_pretraining_paper_large --resume ./weights/mae_pretrain_vit_large_full.pth --model mae_vit_large_patch16
+# CUDA_VISIBLE_DEVICES=0 python FSC_finetune_cross.py --epochs 1000 --batch_size 8 --lr 1e-5 --output_dir ./data/out/finetune_large --log_dir None --title CounTR_finetuning_paper_large --resume ./data/out/pretrain_large/checkpoint__pretraining_299.pth --model mae_vit_large_patch16
+# python FSC_test_cross\(few-shot\).py --output_dir ./data/out/results_large --resume ./data/out/finetune_large/checkpoint__finetuning_minMAE.pth --box_bound 3 --model mae_vit_large_patch16

--- a/util/FSC147.py
+++ b/util/FSC147.py
@@ -1,4 +1,6 @@
 import json
+from pathlib import Path
+
 import numpy as np
 import random
 from torchvision import transforms
@@ -8,37 +10,37 @@ import torchvision.transforms.functional as TF
 import scipy.ndimage as ndimage
 from PIL import Image
 
-import imgaug as ia
 import imgaug.augmenters as iaa
 from imgaug.augmentables import Keypoint, KeypointsOnImage
-
 
 MAX_HW = 384
 IM_NORM_MEAN = [0.485, 0.456, 0.406]
 IM_NORM_STD = [0.229, 0.224, 0.225]
 
-data_path = '/GPFS/data/changliu/FSC147/'
-im_dir = data_path + 'images_384_VarV2'
 
-anno_file = data_path + 'annotation_FSC147_384.json'
-data_split_file = data_path + 'Train_Test_Val_FSC_147.json'
-class_file = data_path + 'ImageClasses_FSC147.txt'
+class ResizeSomeImage(object):
+    def __init__(self, data_path=Path('./data/FSC147/')):
+        self.im_dir = data_path / 'images_384_VarV2'
+        anno_file = data_path / 'annotation_FSC147_384.json'
+        data_split_file = data_path / 'Train_Test_Val_FSC_147.json'
+        class_file = data_path / 'ImageClasses_FSC147.txt'
 
-with open(anno_file) as f:
-    annotations = json.load(f)
+        with open(anno_file) as f:
+            self.annotations = json.load(f)
 
-with open(data_split_file) as f:
-    data_split = json.load(f)
+        with open(data_split_file) as f:
+            data_split = json.load(f)
 
-class_dict = {}
-with open(class_file) as f:
-    for line in f:
-        key = line.split()[0]
-        val = line.split()[1:]
-        class_dict[key] = val
-train_set = data_split['train']
+        self.class_dict = {}
+        with open(class_file) as f:
+            for line in f:
+                key = line.split()[0]
+                val = line.split()[1:]
+                self.class_dict[key] = val
+        self.train_set = data_split['train']
 
-class resizePreTrainImage(object):
+
+class ResizePreTrainImage(ResizeSomeImage):
     """
     Resize the image so that:
         1. Image is equal to 384 * 384
@@ -46,17 +48,18 @@ class resizePreTrainImage(object):
         3. The aspect ratio is preserved
     Density and boxes correctness not preserved(crop and horizontal flip)
     """
-    
-    def __init__(self, MAX_HW=384):
+
+    def __init__(self, data_path=Path('./data/FSC147/'), MAX_HW=384):
+        super().__init__(data_path)
         self.max_hw = MAX_HW
 
     def __call__(self, sample):
-        image,lines_boxes,density = sample['image'], sample['lines_boxes'],sample['gt_density']
-        
+        image, lines_boxes, density = sample['image'], sample['lines_boxes'], sample['gt_density']
+
         W, H = image.size
 
-        new_H = 16*int(H/16)
-        new_W = 16*int(W/16)
+        new_H = 16 * int(H / 16)
+        new_W = 16 * int(W / 16)
         '''scale_factor = float(256)/ H
         new_H = 16*int(H*scale_factor/16)
         new_W = 16*int(W*scale_factor/16)'''
@@ -65,21 +68,23 @@ class resizePreTrainImage(object):
         orig_count = np.sum(density)
         new_count = np.sum(resized_density)
 
-        if new_count > 0: resized_density = resized_density * (orig_count / new_count)
-            
+        if new_count > 0:
+            resized_density = resized_density * (orig_count / new_count)
+
         boxes = list()
         for box in lines_boxes:
             box2 = [int(k) for k in box]
             y1, x1, y2, x2 = box2[0], box2[1], box2[2], box2[3]
-            boxes.append([0, y1,x1,y2,x2])
+            boxes.append([0, y1, x1, y2, x2])
 
         boxes = torch.Tensor(boxes).unsqueeze(0)
         resized_image = PreTrainNormalize(resized_image)
         resized_density = torch.from_numpy(resized_density).unsqueeze(0).unsqueeze(0)
-        sample = {'image':resized_image,'boxes':boxes,'gt_density':resized_density}
+        sample = {'image': resized_image, 'boxes': boxes, 'gt_density': resized_density}
         return sample
 
-class resizeTrainImage(object):
+
+class ResizeTrainImage(ResizeSomeImage):
     """
     Resize the image so that:
         1. Image is equal to 384 * 384
@@ -89,28 +94,30 @@ class resizeTrainImage(object):
     Exemplar boxes may be outside the cropped area.
     Augmentation including Gaussian noise, Color jitter, Gaussian blur, Random affine, Random horizontal flip and Mosaic (or Random Crop if no Mosaic) is used.
     """
-    
-    def __init__(self, MAX_HW=384):
+
+    def __init__(self, data_path=Path('./data/FSC147/'), MAX_HW=384):
+        super().__init__(data_path)
         self.max_hw = MAX_HW
 
     def __call__(self, sample):
-        image, lines_boxes, density, dots, im_id, m_flag = sample['image'], sample['lines_boxes'],sample['gt_density'], sample['dots'], sample['id'], sample['m_flag']
-        
+        image, lines_boxes, density, dots, im_id, m_flag = sample['image'], sample['lines_boxes'], sample['gt_density'], \
+            sample['dots'], sample['id'], sample['m_flag']
+
         W, H = image.size
 
-        new_H = 16*int(H/16)
-        new_W = 16*int(W/16)
-        scale_factor = float(new_W)/ W
+        new_H = 16 * int(H / 16)
+        new_W = 16 * int(W / 16)
+        scale_factor = float(new_W) / W
         resized_image = transforms.Resize((new_H, new_W))(image)
-        resized_density = cv2.resize(density, (new_W, new_H))   
-        
+        resized_density = cv2.resize(density, (new_W, new_H))
+
         # Augmentation probability
         aug_p = random.random()
         aug_flag = 0
         mosaic_flag = 0
-        if aug_p < 0.4: # 0.4
+        if aug_p < 0.4:  # 0.4
             aug_flag = 1
-            if aug_p < 0.25: # 0.25
+            if aug_p < 0.25:  # 0.25
                 aug_flag = 0
                 mosaic_flag = 1
 
@@ -128,27 +135,28 @@ class resizeTrainImage(object):
 
         # Random affine
         if aug_flag == 1:
-            re1_image = re_image.transpose(0,1).transpose(1,2).numpy()
+            re1_image = re_image.transpose(0, 1).transpose(1, 2).numpy()
             keypoints = []
             for i in range(dots.shape[0]):
-                keypoints.append(Keypoint(x=min(new_W-1,int(dots[i][0]*scale_factor)), y=min(new_H-1,int(dots[i][1]))))
+                keypoints.append(Keypoint(x=min(new_W - 1, int(dots[i][0] * scale_factor)), y=min(new_H - 1, int(dots[i][1]))))
             kps = KeypointsOnImage(keypoints, re1_image.shape)
 
             seq = iaa.Sequential([
                 iaa.Affine(
-                    rotate=(-15,15),
+                    rotate=(-15, 15),
                     scale=(0.8, 1.2),
-                    shear=(-10,10),
-                    translate_percent={"x": (-0.2,0.2), "y": (-0.2,0.2)}
+                    shear=(-10, 10),
+                    translate_percent={"x": (-0.2, 0.2), "y": (-0.2, 0.2)}
                 )
             ])
             re1_image, kps_aug = seq(image=re1_image, keypoints=kps)
 
             # Produce dot annotation map
-            resized_density = np.zeros((resized_density.shape[0], resized_density.shape[1]),dtype='float32')
+            resized_density = np.zeros((resized_density.shape[0], resized_density.shape[1]), dtype='float32')
             for i in range(len(kps.keypoints)):
-                if(int(kps_aug.keypoints[i].y)<= new_H-1 and int(kps_aug.keypoints[i].x)<=new_W-1) and not kps_aug.keypoints[i].is_out_of_image(re1_image):
-                    resized_density[int(kps_aug.keypoints[i].y)][int(kps_aug.keypoints[i].x)]=1
+                if (int(kps_aug.keypoints[i].y) <= new_H - 1 and int(kps_aug.keypoints[i].x) <= new_W - 1) and not \
+                        kps_aug.keypoints[i].is_out_of_image(re1_image):
+                    resized_density[int(kps_aug.keypoints[i].y)][int(kps_aug.keypoints[i].x)] = 1
             resized_density = torch.from_numpy(resized_density)
 
             re_image = TTensor(re1_image)
@@ -159,19 +167,19 @@ class resizeTrainImage(object):
             if flip_p > 0.5:
                 re_image = TF.hflip(re_image)
                 resized_density = TF.hflip(resized_density)
-        
+
         # Random 384*384 crop in a new_W*384 image and 384*new_W density map
         if mosaic_flag == 0:
             if aug_flag == 0:
                 re_image = resized_image
-                resized_density = np.zeros((resized_density.shape[0], resized_density.shape[1]),dtype='float32')
+                resized_density = np.zeros((resized_density.shape[0], resized_density.shape[1]), dtype='float32')
                 for i in range(dots.shape[0]):
-                    resized_density[min(new_H-1,int(dots[i][1]))][min(new_W-1,int(dots[i][0]*scale_factor))]=1
+                    resized_density[min(new_H - 1, int(dots[i][1]))][min(new_W - 1, int(dots[i][0] * scale_factor))] = 1
                 resized_density = torch.from_numpy(resized_density)
 
-            start = random.randint(0, new_W-1-383)
+            start = random.randint(0, new_W - 1 - 383)
             reresized_image = TF.crop(re_image, 0, start, 384, 384)
-            reresized_density = resized_density[:, start:start+384]
+            reresized_density = resized_density[:, start:start + 384]
         # Random self mosaic
         else:
             image_array = []
@@ -180,14 +188,14 @@ class resizeTrainImage(object):
             resize_l = 192 + 2 * blending_l
             if dots.shape[0] >= 70:
                 for i in range(4):
-                    length =  random.randint(150, 384)
-                    start_W = random.randint(0, new_W-length)
-                    start_H = random.randint(0, new_H-length)
+                    length = random.randint(150, 384)
+                    start_W = random.randint(0, new_W - length)
+                    start_H = random.randint(0, new_H - length)
                     reresized_image1 = TF.crop(resized_image, start_H, start_W, length, length)
                     reresized_image1 = transforms.Resize((resize_l, resize_l))(reresized_image1)
-                    reresized_density1 = np.zeros((resize_l,resize_l),dtype='float32')
+                    reresized_density1 = np.zeros((resize_l, resize_l), dtype='float32')
                     for i in range(dots.shape[0]):
-                        if min(new_H-1,int(dots[i][1])) >= start_H and min(new_H-1,int(dots[i][1])) < start_H + length and min(new_W-1,int(dots[i][0]*scale_factor)) >= start_W and min(new_W-1,int(dots[i][0]*scale_factor)) < start_W + length:
+                        if start_H <= min(new_H - 1, int(dots[i][1])) < start_H + length and start_W <= min(new_W - 1, int(dots[i][0] * scale_factor)) < start_W + length:
                             reresized_density1[min(resize_l-1,int((min(new_H-1,int(dots[i][1]))-start_H)*resize_l/length))][min(resize_l-1,int((min(new_W-1,int(dots[i][0]*scale_factor))-start_W)*resize_l/length))]=1
                     reresized_density1 = torch.from_numpy(reresized_density1)
                     image_array.append(reresized_image1)
@@ -196,9 +204,9 @@ class resizeTrainImage(object):
                 m_flag = 1
                 prob = random.random()
                 if prob > 0.25:
-                    gt_pos = random.randint(0,3)
+                    gt_pos = random.randint(0, 3)
                 else:
-                    gt_pos = random.randint(0,4) # 5% 0 objects
+                    gt_pos = random.randint(0, 4)  # 5% 0 objects
                 for i in range(4):
                     if i == gt_pos:
                         Tim_id = im_id
@@ -208,102 +216,106 @@ class resizeTrainImage(object):
                         new_TW = new_W
                         Tscale_factor = scale_factor
                     else:
-                        Tim_id = train_set[random.randint(0, len(train_set)-1)]
-                        Tdots = np.array(annotations[Tim_id]['points'])
+                        Tim_id = self.train_set[random.randint(0, len(self.train_set) - 1)]
+                        Tdots = np.array(self.annotations[Tim_id]['points'])
                         '''while(abs(Tdots.shape[0]-dots.shape[0]<=10)):
                             Tim_id = train_set[random.randint(0, len(train_set)-1)]
                             Tdots = np.array(annotations[Tim_id]['points'])'''
-                        Timage = Image.open('{}/{}'.format(im_dir, Tim_id))
+                        Timage = Image.open('{}/{}'.format(self.im_dir, Tim_id))
                         Timage.load()
-                        new_TH = 16*int(Timage.size[1]/16)
-                        new_TW = 16*int(Timage.size[0]/16)
-                        Tscale_factor = float(new_TW)/ Timage.size[0]
+                        new_TH = 16 * int(Timage.size[1] / 16)
+                        new_TW = 16 * int(Timage.size[0] / 16)
+                        Tscale_factor = float(new_TW) / Timage.size[0]
                         r_image = TTensor(transforms.Resize((new_TH, new_TW))(Timage))
 
-                    length =  random.randint(250, 384)
-                    start_W = random.randint(0, new_TW-length)
-                    start_H = random.randint(0, new_TH-length)
+                    length = random.randint(250, 384)
+                    start_W = random.randint(0, new_TW - length)
+                    start_H = random.randint(0, new_TH - length)
                     r_image1 = TF.crop(r_image, start_H, start_W, length, length)
                     r_image1 = transforms.Resize((resize_l, resize_l))(r_image1)
-                    r_density1 = np.zeros((resize_l,resize_l),dtype='float32')
-                    if class_dict[im_id] == class_dict[Tim_id]:
+                    r_density1 = np.zeros((resize_l, resize_l), dtype='float32')
+                    if self.class_dict[im_id] == self.class_dict[Tim_id]:
                         for i in range(Tdots.shape[0]):
-                            if min(new_TH-1,int(Tdots[i][1])) >= start_H and min(new_TH-1,int(Tdots[i][1])) < start_H + length and min(new_TW-1,int(Tdots[i][0]*Tscale_factor)) >= start_W and min(new_TW-1,int(Tdots[i][0]*Tscale_factor)) < start_W + length:
+                            if start_H <= min(new_TH - 1, int(Tdots[i][1])) < start_H + length and start_W <= min(new_TW - 1, int(Tdots[i][0] * Tscale_factor)) < start_W + length:
                                 r_density1[min(resize_l-1,int((min(new_TH-1,int(Tdots[i][1]))-start_H)*resize_l/length))][min(resize_l-1,int((min(new_TW-1,int(Tdots[i][0]*Tscale_factor))-start_W)*resize_l/length))]=1
                     r_density1 = torch.from_numpy(r_density1)
                     image_array.append(r_image1)
                     map_array.append(r_density1)
 
-
-            reresized_image5 = torch.cat((image_array[0][:,blending_l:resize_l-blending_l],image_array[1][:,blending_l:resize_l-blending_l]),1)
-            reresized_density5 = torch.cat((map_array[0][blending_l:resize_l-blending_l],map_array[1][blending_l:resize_l-blending_l]),0)
+            reresized_image5 = torch.cat((image_array[0][:, blending_l:resize_l-blending_l], image_array[1][:, blending_l: resize_l-blending_l]), 1)
+            reresized_density5 = torch.cat((map_array[0][blending_l:resize_l-blending_l], map_array[1][blending_l: resize_l-blending_l]), 0)
             for i in range(blending_l):
-                    reresized_image5[:,192+i] = image_array[0][:,resize_l-1-blending_l+i] * (blending_l-i)/(2*blending_l) + reresized_image5[:,192+i] * (i+blending_l)/(2*blending_l)
-                    reresized_image5[:,191-i] = image_array[1][:,blending_l-i] * (blending_l-i)/(2*blending_l) + reresized_image5[:,191-i] * (i+blending_l)/(2*blending_l)
+                    reresized_image5[:, 192+i] = image_array[0][:, resize_l-1-blending_l+i] * (blending_l-i)/(2 * blending_l) + reresized_image5[:, 192+i] * (i+blending_l)/(2*blending_l)
+                    reresized_image5[:, 191-i] = image_array[1][:, blending_l-i] * (blending_l-i)/(2*blending_l) + reresized_image5[:, 191-i] * (i+blending_l)/(2*blending_l)
             reresized_image5 = torch.clamp(reresized_image5, 0, 1)
 
-            reresized_image6 = torch.cat((image_array[2][:,blending_l:resize_l-blending_l],image_array[3][:,blending_l:resize_l-blending_l]),1)
-            reresized_density6 = torch.cat((map_array[2][blending_l:resize_l-blending_l],map_array[3][blending_l:resize_l-blending_l]),0)
+            reresized_image6 = torch.cat((image_array[2][:, blending_l:resize_l-blending_l], image_array[3][:, blending_l: resize_l-blending_l]), 1)
+            reresized_density6 = torch.cat((map_array[2][blending_l:resize_l-blending_l], map_array[3][blending_l:resize_l-blending_l]), 0)
             for i in range(blending_l):
-                    reresized_image6[:,192+i] = image_array[2][:,resize_l-1-blending_l+i] * (blending_l-i)/(2*blending_l) + reresized_image6[:,192+i] * (i+blending_l)/(2*blending_l)
-                    reresized_image6[:,191-i] = image_array[3][:,blending_l-i] * (blending_l-i)/(2*blending_l) + reresized_image6[:,191-i] * (i+blending_l)/(2*blending_l)
+                    reresized_image6[:, 192+i] = image_array[2][:, resize_l-1-blending_l+i] * (blending_l-i)/(2*blending_l) + reresized_image6[:, 192+i] * (i+blending_l)/(2*blending_l)
+                    reresized_image6[:, 191-i] = image_array[3][:, blending_l-i] * (blending_l-i)/(2*blending_l) + reresized_image6[:, 191-i] * (i+blending_l)/(2*blending_l)
             reresized_image6 = torch.clamp(reresized_image6, 0, 1)
 
-            reresized_image = torch.cat((reresized_image5[:,:,blending_l:resize_l-blending_l],reresized_image6[:,:,blending_l:resize_l-blending_l]),2)
-            reresized_density = torch.cat((reresized_density5[:,blending_l:resize_l-blending_l],reresized_density6[:,blending_l:resize_l-blending_l]),1)
+            reresized_image = torch.cat((reresized_image5[:, :, blending_l:resize_l-blending_l], reresized_image6[:, :, blending_l:resize_l-blending_l]), 2)
+            reresized_density = torch.cat((reresized_density5[:, blending_l:resize_l-blending_l], reresized_density6[:, blending_l:resize_l-blending_l]), 1)
             for i in range(blending_l):
-                    reresized_image[:,:,192+i] = reresized_image5[:,:,resize_l-1-blending_l+i] * (blending_l-i)/(2*blending_l) + reresized_image[:,:,192+i] * (i+blending_l)/(2*blending_l)
-                    reresized_image[:,:,191-i] = reresized_image6[:,:,blending_l-i] * (blending_l-i)/(2*blending_l) + reresized_image[:,:,191-i] * (i+blending_l)/(2*blending_l)
+                    reresized_image[:, :, 192+i] = reresized_image5[:, :, resize_l-1-blending_l+i] * (blending_l-i)/(2*blending_l) + reresized_image[:, :, 192+i] * (i+blending_l)/(2*blending_l)
+                    reresized_image[:, :, 191-i] = reresized_image6[:, :, blending_l-i] * (blending_l-i)/(2*blending_l) + reresized_image[:, :, 191-i] * (i+blending_l)/(2*blending_l)
             reresized_image = torch.clamp(reresized_image, 0, 1)
-        
+
         # Gaussian distribution density map
         reresized_density = ndimage.gaussian_filter(reresized_density.numpy(), sigma=(1, 1), order=0)
 
         # Density map scale up
         reresized_density = reresized_density * 60
         reresized_density = torch.from_numpy(reresized_density)
-            
+
         # Crop bboxes and resize as 64x64
         boxes = list()
         cnt = 0
         for box in lines_boxes:
-            cnt+=1
-            if cnt>3:
+            cnt += 1
+            if cnt > 3:
                 break
             box2 = [int(k) for k in box]
-            y1, x1, y2, x2 = box2[0], int(box2[1]*scale_factor), box2[2], int(box2[3]*scale_factor)
-            bbox = resized_image[:,y1:y2+1,x1:x2+1]
+            y1, x1, y2, x2 = box2[0], int(box2[1] * scale_factor), box2[2], int(box2[3] * scale_factor)
+            bbox = resized_image[:, y1:y2 + 1, x1:x2 + 1]
             bbox = transforms.Resize((64, 64))(bbox)
             boxes.append(bbox.numpy())
         boxes = np.array(boxes)
         boxes = torch.Tensor(boxes)
 
-        
-        # boxes shape [3,3,64,64], image shape [3,384,384], density shape[384,384]       
-        sample = {'image':reresized_image,'boxes':boxes,'gt_density':reresized_density, 'm_flag': m_flag}
+        # boxes shape [3,3,64,64], image shape [3,384,384], density shape[384,384]
+        sample = {'image': reresized_image, 'boxes': boxes, 'gt_density': reresized_density, 'm_flag': m_flag}
 
         return sample
 
-PreTrainNormalize = transforms.Compose([   
-        transforms.RandomResizedCrop(384, scale=(0.2, 1.0), interpolation=3), 
-        transforms.RandomHorizontalFlip(),
-        transforms.ToTensor(),
-        #transforms.Normalize(mean=IM_NORM_MEAN, std=IM_NORM_STD)
-        ])
 
-TTensor = transforms.Compose([   
-        transforms.ToTensor(),
-        ])
+PreTrainNormalize = transforms.Compose([
+    transforms.RandomResizedCrop(384, scale=(0.2, 1.0), interpolation=3),
+    transforms.RandomHorizontalFlip(),
+    transforms.ToTensor(),
+    # transforms.Normalize(mean=IM_NORM_MEAN, std=IM_NORM_STD)
+])
 
-Augmentation = transforms.Compose([   
-        transforms.ColorJitter(brightness=0.25, contrast=0.15, saturation=0.15, hue=0.15),
-        transforms.GaussianBlur(kernel_size=(7,9))
-        ])
+TTensor = transforms.Compose([
+    transforms.ToTensor(),
+])
 
-Normalize = transforms.Compose([   
-        transforms.ToTensor(),
-        transforms.Normalize(mean=IM_NORM_MEAN, std=IM_NORM_STD)
-        ])
+Augmentation = transforms.Compose([
+    transforms.ColorJitter(brightness=0.25, contrast=0.15, saturation=0.15, hue=0.15),
+    transforms.GaussianBlur(kernel_size=(7, 9))
+])
 
-TransformTrain = transforms.Compose([resizeTrainImage(MAX_HW)])
-TransformPreTrain = transforms.Compose([resizePreTrainImage(MAX_HW)])
+Normalize = transforms.Compose([
+    transforms.ToTensor(),
+    transforms.Normalize(mean=IM_NORM_MEAN, std=IM_NORM_STD)
+])
+
+
+def transform_train(data_path: Path):
+    return transforms.Compose([ResizeTrainImage(data_path, MAX_HW)])
+
+
+def transform_pre_train(data_path: Path):
+    return transforms.Compose([ResizePreTrainImage(data_path, MAX_HW)])


### PR DESCRIPTION
Added:
 - Logging of pre-training and fine-tuning on **[WandB](https://wandb.ai/)**:
   - **metrics** of pre-training (loss and learning rate) and fine-tuning (loss, learning rate, MAE, RMSE);
   - images of **predictions** produced by the forward pass of the **pre-training** every _t_ steps (original, masked, recovered);
   - images of **exemplars and predictions** produced by the forward pass of the **fine-tuning** every _t_ steps (GT, predicted density map, overlay of input + prediction);
   - model **weights** every _n_ epochs for pre-training and fine-tuning, and the model with minimum MAE for fine-tuning.
 - New **bash script** `run.sh` to reproduce results and/or run paper's pre-training and fine-tuning.
 - **Parametric paths** in `FSC147.py`, `FSC_pretrain.py`, `FSC_finetune_cross.py`.

Some examples of images logged during pre-training 
![image](https://user-images.githubusercontent.com/11423697/216380047-483ca2bc-b973-4fd4-82c3-d31da770f0d2.png)
and fine-tuning
![image](https://user-images.githubusercontent.com/11423697/216380396-a23d33fc-7a08-4428-b7cd-7121428d6ca5.png)
