### PR TITLE
More flexible fine-tuning and testing, more logs, zero-shot demo, minimal run examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 **.ini
 **.pth
+**.zip
 **__pycache__
 .idea/
 /data/

--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,9 @@
 **.ini
 **.pth
-!weights/FSC147.pth
 **__pycache__
 .idea/
-/data/*
-!/data/foring00025.png
-!/data/letsea_14/annotations_few.json
-!/data/letsea_14/annotations_zero.json
-!/data/letsea_14/split.json
+/data/
 /logs/
 /wandb/
+/results/
+/env/

--- a/FSC_finetune_cross.py
+++ b/FSC_finetune_cross.py
@@ -6,17 +6,16 @@ import os
 import time
 import random
 from pathlib import Path
-import math
 import sys
 from PIL import Image
 
 import torch
 import torch.backends.cudnn as cudnn
-from torch.utils.tensorboard import SummaryWriter
 from torch.utils.data import Dataset
 import torchvision
 import wandb
 import timm
+from tqdm import tqdm
 
 assert "0.4.5" <= timm.__version__ <= "0.4.9"  # version check
 import timm.optim.optim_factory as optim_factory
@@ -24,7 +23,7 @@ import timm.optim.optim_factory as optim_factory
 import util.misc as misc
 from util.misc import NativeScalerWithGradNormCount as NativeScaler
 import util.lr_sched as lr_sched
-from util.FSC147 import transform_train
+from util.FSC147 import transform_train, transform_val
 import models_mae_cross
 
 
@@ -39,10 +38,8 @@ def get_args_parser():
     # Model parameters
     parser.add_argument('--model', default='mae_vit_base_patch16', type=str, metavar='MODEL',
                         help='Name of model to train')
-
     parser.add_argument('--mask_ratio', default=0.5, type=float,
                         help='Masking ratio (percentage of removed patches).')
-
     parser.add_argument('--norm_pix_loss', action='store_true',
                         help='Use (per-patch) normalized pixels as targets for computing loss')
     parser.set_defaults(norm_pix_loss=False)
@@ -70,8 +67,6 @@ def get_args_parser():
                         help='class json file')
     parser.add_argument('--im_dir', default='images_384_VarV2', type=str,
                         help='images directory')
-    parser.add_argument('--gt_dir', default='gt_density_map_adaptive_384_VarV2', type=str,
-                        help='ground truth directory')
     parser.add_argument('--output_dir', default='./data/out/fim6_dir',
                         help='path where to save, empty for no saving')
     parser.add_argument('--device', default='cuda',
@@ -79,6 +74,8 @@ def get_args_parser():
     parser.add_argument('--seed', default=0, type=int)
     parser.add_argument('--resume', default='./data/out/pre_4_dir/checkpoint-300.pth',
                         help='resume from checkpoint')
+    parser.add_argument('--do_resume', action='store_true',
+                        help='Resume training (e.g. if crashed).')
 
     # Training parameters
     parser.add_argument('--start_epoch', default=0, type=int, metavar='N',
@@ -88,6 +85,10 @@ def get_args_parser():
                         help='Pin CPU memory in DataLoader for more efficient (sometimes) transfer to GPU.')
     parser.add_argument('--no_pin_mem', action='store_false', dest='pin_mem')
     parser.set_defaults(pin_mem=True)
+    parser.add_argument('--do_aug', action='store_true',
+                        help='Perform data augmentation.')
+    parser.add_argument('--no_do_aug', action='store_false', dest='do_aug')
+    parser.set_defaults(do_aug=True)
 
     # Distributed training parameters
     parser.add_argument('--world_size', default=1, type=int,
@@ -98,8 +99,6 @@ def get_args_parser():
                         help='url used to set up distributed training')
 
     # Logging parameters
-    parser.add_argument('--log_dir', default='./logs/fim6_dir',
-                        help='path where to tensorboard log')
     parser.add_argument("--title", default="CounTR_finetuning", type=str)
     parser.add_argument("--wandb", default="counting", type=str)
     parser.add_argument("--team", default="wsense", type=str)
@@ -112,19 +111,29 @@ os.environ["CUDA_LAUNCH_BLOCKING"] = '1'
 
 
 class TrainData(Dataset):
-    def __init__(self):
-        self.img = data_split['train']
+    def __init__(self, args, split='train', do_aug=True):
+        with open(args.anno_file) as f:
+            annotations = json.load(f)
+        with open(args.data_split_file) as f:
+            data_split = json.load(f)
+
+        self.img = data_split[split]
         random.shuffle(self.img)
+        self.split = split
         self.img_dir = im_dir
-        self.TransformTrain = transform_train(data_path)
+        self.TransformTrain = transform_train(args, do_aug=do_aug)
+        self.TransformVal = transform_val(args)
+        self.annotations = annotations
+        self.im_dir = im_dir
 
     def __len__(self):
         return len(self.img)
 
     def __getitem__(self, idx):
         im_id = self.img[idx]
-        anno = annotations[im_id]
+        anno = self.annotations[im_id]
         bboxes = anno['box_examples_coordinates']
+        dots = np.array(anno['points'])
 
         rects = list()
         for bbox in bboxes:
@@ -134,306 +143,308 @@ class TrainData(Dataset):
             y2 = bbox[2][1]
             rects.append([y1, x1, y2, x2])
 
-        dots = np.array(anno['points'])
-
-        image = Image.open('{}/{}'.format(im_dir, im_id))
+        image = Image.open('{}/{}'.format(self.im_dir, im_id))
+        if image.mode == "RGBA":
+            image = image.convert("RGB")
         image.load()
-        density_path = gt_dir / (im_id.split(".jpg")[0] + ".npy")
-        density = np.load(density_path).astype('float32')
         m_flag = 0
 
-        sample = {'image': image, 'lines_boxes': rects, 'gt_density': density, 'dots': dots, 'id': im_id,
-                  'm_flag': m_flag}
-        sample = self.TransformTrain(sample)
-        return sample['image'], sample['gt_density'], sample['boxes'], sample['m_flag']
+        sample = {'image': image, 'lines_boxes': rects, 'dots': dots, 'id': im_id, 'm_flag': m_flag}
+        sample = self.TransformTrain(sample) if self.split == "train" else self.TransformVal(sample)
+        return sample['image'], sample['gt_density'], len(dots), sample['boxes'], sample['m_flag'], im_id
 
 
 def main(args):
-    misc.init_distributed_mode(args)
+    wandb_run = None
+    try:
+        misc.init_distributed_mode(args)
 
-    print('job dir: {}'.format(os.path.dirname(os.path.realpath(__file__))))
-    print("{}".format(args).replace(', ', ',\n'))
+        print('job dir: {}'.format(os.path.dirname(os.path.realpath(__file__))))
+        print("{}".format(args).replace(', ', ',\n'))
 
-    device = torch.device(args.device)
+        device = torch.device(args.device)
 
-    # fix the seed for reproducibility
-    seed = args.seed + misc.get_rank()
-    torch.manual_seed(seed)
-    np.random.seed(seed)
+        # fix the seed for reproducibility
+        seed = args.seed + misc.get_rank()
+        torch.manual_seed(seed)
+        np.random.seed(seed)
+        cudnn.benchmark = True
 
-    cudnn.benchmark = True
+        dataset_train = TrainData(args, do_aug=args.do_aug)
+        dataset_val = TrainData(args, split='val')
 
-    dataset_train = TrainData()
-    print(dataset_train)
-
-    if True:  # args.distributed:
         num_tasks = misc.get_world_size()
         global_rank = misc.get_rank()
         sampler_train = torch.utils.data.DistributedSampler(
             dataset_train, num_replicas=num_tasks, rank=global_rank, shuffle=True
         )
-        print("Sampler_train = %s" % str(sampler_train))
-    else:
-        sampler_train = torch.utils.data.RandomSampler(dataset_train)
+        sampler_val = torch.utils.data.DistributedSampler(
+            dataset_val, num_replicas=num_tasks, rank=global_rank, shuffle=True
+        )
 
-    if global_rank == 0:
-        if args.log_dir is not None:
-            os.makedirs(args.log_dir, exist_ok=True)
-            log_writer = SummaryWriter(log_dir=args.log_dir)
-        else:
-            log_writer = None
-        if args.wandb is not None:
-            wandb_run = wandb.init(
-                config=args,
-                resume="allow",
-                project=args.wandb,
-                name=args.title,
-                entity=args.team,
-                tags=["CounTR", "finetuning"],
-                id=args.wandb_id,
-            )
-        else:
-            wandb_run = None
+        if global_rank == 0:
+            if args.wandb is not None:
+                wandb_run = wandb.init(
+                    config=args,
+                    resume="allow",
+                    project=args.wandb,
+                    name=args.title,
+                    entity=args.team,
+                    tags=["CounTR", "finetuning"],
+                    id=args.wandb_id,
+                )
 
-    data_loader_train = torch.utils.data.DataLoader(
-        dataset_train, sampler=sampler_train,
-        batch_size=args.batch_size,
-        num_workers=args.num_workers,
-        pin_memory=args.pin_mem,
-        drop_last=False,
-    )
+        data_loader_train = torch.utils.data.DataLoader(
+            dataset_train, sampler=sampler_train,
+            batch_size=args.batch_size,
+            num_workers=args.num_workers,
+            pin_memory=args.pin_mem,
+            drop_last=False,
+        )
+        data_loader_val = torch.utils.data.DataLoader(
+            dataset_val, sampler=sampler_val,
+            batch_size=args.batch_size,
+            num_workers=args.num_workers,
+            pin_memory=args.pin_mem,
+            drop_last=False,
+        )
 
-    # define the model
-    model = models_mae_cross.__dict__[args.model](norm_pix_loss=args.norm_pix_loss)
+        # define the model
+        model = models_mae_cross.__dict__[args.model](norm_pix_loss=args.norm_pix_loss)
+        model.to(device)
+        model_without_ddp = model
+        print("Model = %s" % str(model_without_ddp))
 
-    model.to(device)
+        eff_batch_size = args.batch_size * args.accum_iter * misc.get_world_size()
 
-    model_without_ddp = model
+        if args.lr is None:  # only base_lr is specified
+            args.lr = args.blr * eff_batch_size / 256
 
-    print("Model = %s" % str(model_without_ddp))
+        print("base lr: %.2e" % (args.lr * 256 / eff_batch_size))
+        print("actual lr: %.2e" % args.lr)
 
-    eff_batch_size = args.batch_size * args.accum_iter * misc.get_world_size()
+        print("accumulate grad iterations: %d" % args.accum_iter)
+        print("effective batch size: %d" % eff_batch_size)
 
-    if args.lr is None:  # only base_lr is specified
-        args.lr = args.blr * eff_batch_size / 256
-
-    print("base lr: %.2e" % (args.lr * 256 / eff_batch_size))
-    print("actual lr: %.2e" % args.lr)
-
-    print("accumulate grad iterations: %d" % args.accum_iter)
-    print("effective batch size: %d" % eff_batch_size)
-
-    if args.distributed:
-        model = torch.nn.parallel.DistributedDataParallel(model, device_ids=[args.gpu], find_unused_parameters=True)
-        model_without_ddp = model.module
-
-    # following timm: set wd as 0 for bias and norm layers
-    param_groups = optim_factory.add_weight_decay(model_without_ddp, args.weight_decay)
-    optimizer = torch.optim.AdamW(param_groups, lr=args.lr, betas=(0.9, 0.95))
-    print(optimizer)
-
-    loss_scaler = NativeScaler()
-
-    min_MAE = 99999
-
-    misc.load_model_FSC(args=args, model_without_ddp=model_without_ddp)
-
-    print(f"Start training for {args.epochs} epochs")
-    start_time = time.time()
-    for epoch in range(args.start_epoch, args.epochs):
         if args.distributed:
-            data_loader_train.sampler.set_epoch(epoch)
+            model = torch.nn.parallel.DistributedDataParallel(model, device_ids=[args.gpu], find_unused_parameters=True)
+            model_without_ddp = model.module
 
-        # train one epoch
-        model.train(True)
-        metric_logger = misc.MetricLogger(delimiter="  ")
-        metric_logger.add_meter('lr', misc.SmoothedValue(window_size=1, fmt='{value:.6f}'))
-        header = 'Epoch: [{}]'.format(epoch)
-        print_freq = 20
-        accum_iter = args.accum_iter
+        # following timm: set wd as 0 for bias and norm layers
+        param_groups = optim_factory.add_weight_decay(model_without_ddp, args.weight_decay)
+        optimizer = torch.optim.AdamW(param_groups, lr=args.lr, betas=(0.9, 0.95))
+        print(optimizer)
 
-        # some parameters in training
-        train_mae = 0
-        train_rmse = 0
-        pred_cnt = 0
-        gt_cnt = 0
+        loss_scaler = NativeScaler()
 
-        optimizer.zero_grad()
+        min_MAE = 99999
+        print_freq = 2  # 50
+        save_freq = 2  # 50
 
-        if log_writer is not None:
-            print('log_dir: {}'.format(log_writer.log_dir))
+        misc.load_model_FSC_full(args=args, model_without_ddp=model_without_ddp, optimizer=optimizer, loss_scaler=loss_scaler)
 
-        for data_iter_step, (samples, gt_density, boxes, m_flag) in enumerate(
-                metric_logger.log_every(data_loader_train, print_freq, header)):
-            epoch_1000x = int((data_iter_step / len(data_loader_train) + epoch) * 1000)
+        print(f"Start training for {args.epochs - args.start_epoch} epochs   -   rank {global_rank}")
+        start_time = time.time()
+        for epoch in range(args.start_epoch, args.epochs):
+            if args.distributed:
+                data_loader_train.sampler.set_epoch(epoch)
 
-            if data_iter_step % accum_iter == 0:
-                lr_sched.adjust_learning_rate(optimizer, data_iter_step / len(data_loader_train) + epoch, args)
+            # train one epoch
+            model.train(True)
+            accum_iter = args.accum_iter
 
-            samples = samples.to(device, non_blocking=True).half()
-            gt_density = gt_density.to(device, non_blocking=True).half()
-            boxes = boxes.to(device, non_blocking=True).half()
+            # some parameters in training
+            train_mae = torch.tensor([0], dtype=torch.float64, device=device)
+            train_mse = torch.tensor([0], dtype=torch.float64, device=device)
+            val_mae = torch.tensor([0], dtype=torch.float64, device=device)
+            val_mse = torch.tensor([0], dtype=torch.float64, device=device)
+            val_nae = torch.tensor([0], dtype=torch.float64, device=device)
 
-            # If there is at least one image in the batch using Type 2 Mosaic, 0-shot is banned.
-            flag = 0
-            for i in range(m_flag.shape[0]):
-                flag += m_flag[i].item()
-            if flag == 0:
+            optimizer.zero_grad()
+
+            for data_iter_step, (samples, gt_density, _, boxes, m_flag, im_names) in enumerate(
+                    tqdm(data_loader_train, total=len(data_loader_train),
+                         desc=f"Train [e. {epoch} - r. {global_rank}]")):
+                idx = data_iter_step + (epoch*len(data_loader_train))
+
+                if data_iter_step % accum_iter == 0:
+                    lr_sched.adjust_learning_rate(optimizer, data_iter_step / len(data_loader_train) + epoch, args)
+
+                samples = samples.to(device, non_blocking=True, dtype=torch.half)
+                gt_density = gt_density.to(device, non_blocking=True, dtype=torch.half)
+                boxes = boxes.to(device, non_blocking=True, dtype=torch.half)
+
+                # If there is at least one image in the batch using Type 2 Mosaic, 0-shot is banned.
+                flag = 0
+                for i in range(m_flag.shape[0]):
+                    flag += m_flag[i].item()
+                if flag == 0:
+                    shot_num = random.randint(0, 3)
+                else:
+                    shot_num = random.randint(1, 3)
+
+                with torch.cuda.amp.autocast():
+                    output = model(samples, boxes, shot_num)
+
+                # Compute loss function
+                mask = np.random.binomial(n=1, p=0.8, size=[384, 384])
+                masks = np.tile(mask, (output.shape[0], 1))
+                masks = masks.reshape(output.shape[0], 384, 384)
+                masks = torch.from_numpy(masks).to(device)
+                loss = (output - gt_density) ** 2
+                loss = (loss * masks / (384 * 384)).sum() / output.shape[0]
+
+                # Update information of MAE and RMSE
+                with torch.no_grad():
+                    pred_cnt = (output.view(len(samples), -1)).sum(1) / 60
+                    gt_cnt = (gt_density.view(len(samples), -1)).sum(1) / 60
+                    cnt_err = torch.abs(pred_cnt - gt_cnt).float()
+                    batch_mae = cnt_err.double().mean()
+                    batch_mse = (cnt_err ** 2).double().mean()
+
+                train_mae += batch_mae
+                train_mse += batch_mse
+
+                if not torch.isfinite(loss):
+                    print("Loss is {}, stopping training".format(loss))
+                    sys.exit(1)
+
+                loss /= accum_iter
+                loss_scaler(loss, optimizer, parameters=model.parameters(),
+                            update_grad=(data_iter_step + 1) % accum_iter == 0)
+                if (data_iter_step + 1) % accum_iter == 0:
+                    optimizer.zero_grad()
+
+                lr = optimizer.param_groups[0]["lr"]
+                loss_value_reduce = misc.all_reduce_mean(loss)
+                if (data_iter_step + 1) % (print_freq * accum_iter) == 0 and (data_iter_step + 1) != len(data_loader_train) and data_iter_step != 0:
+                    if wandb_run is not None:
+                        log = {"train/loss": loss_value_reduce,
+                               "train/lr": lr,
+                               "train/MAE": batch_mae,
+                               "train/RMSE": batch_mse ** 0.5}
+                        wandb.log(log, step=idx)
+
+            # evaluation on Validation split
+            for val_samples, val_gt_density, val_n_ppl, val_boxes, _, val_im_names in \
+                tqdm(data_loader_val, total=len(data_loader_val),
+                     desc=f"Val [e. {epoch} - r. {global_rank}]"):
+
+                val_samples = val_samples.to(device, non_blocking=True, dtype=torch.half)
+                val_gt_density = val_gt_density.to(device, non_blocking=True, dtype=torch.half)
+                val_boxes = val_boxes.to(device, non_blocking=True, dtype=torch.half)
+                val_n_ppl = val_n_ppl.to(device, non_blocking=True)
                 shot_num = random.randint(0, 3)
-            else:
-                shot_num = random.randint(1, 3)
 
-            with torch.cuda.amp.autocast():
-                output = model(samples, boxes, shot_num)
+                with torch.no_grad():
+                    with torch.cuda.amp.autocast():
+                        val_output = model(val_samples, val_boxes, shot_num)
 
-            # Compute loss function
-            mask = np.random.binomial(n=1, p=0.8, size=[384, 384])
-            masks = np.tile(mask, (output.shape[0], 1))
-            masks = masks.reshape(output.shape[0], 384, 384)
-            masks = torch.from_numpy(masks).to(device)
-            loss = (output - gt_density) ** 2
-            loss = (loss * masks / (384 * 384)).sum() / output.shape[0]
+                    val_pred_cnt = (val_output.view(len(val_samples), -1)).sum(1) / 60
+                    val_gt_cnt = (val_gt_density.view(len(val_samples), -1)).sum(1) / 60
+                    val_cnt_err = torch.abs(val_pred_cnt - val_gt_cnt).float()
+                    val_mae += val_cnt_err.double().mean()
+                    val_mse += (val_cnt_err ** 2).double().mean()
+                    _val_nae = val_cnt_err / val_gt_cnt
+                    _val_nae[_val_nae == float('inf')] = 0
+                    val_nae += _val_nae.double().mean()
 
-            loss_value = loss.item()
+            # Output visualisation information to W&B
+            if wandb_run is not None:
+                train_wandb_densities = []
+                train_wandb_bboxes = []
+                val_wandb_densities = []
+                val_wandb_bboxes = []
+                black = torch.zeros([384, 384], device=device)
 
-            # Update information of MAE and RMSE
-            batch_mae = 0
-            batch_rmse = 0
-            for i in range(output.shape[0]):
-                pred_cnt = torch.sum(output[i] / 60).item()
-                gt_cnt = torch.sum(gt_density[i] / 60).item()
-                cnt_err = abs(pred_cnt - gt_cnt)
-                batch_mae += cnt_err
-                batch_rmse += cnt_err ** 2
+                for i in range(output.shape[0]):
+                    fig = torch.stack([output[i], black, black])
+                    f1 = torch.stack([gt_density[i], black, black])
+                    w_gt_density = samples[i] / 2 + f1
+                    w_d_map = fig
+                    w_d_map_overlay = samples[i] / 2 + fig
+                    w_densities = torch.cat([w_gt_density, w_d_map, w_d_map_overlay], dim=2)
+                    w_densities = torch.clamp(w_densities, 0, 1)
+                    train_wandb_densities += [wandb.Image(torchvision.transforms.ToPILImage()(w_densities),
+                                                          caption=f"[E#{epoch}] {im_names[i]} ({torch.sum(gt_density[i]).item()}, {torch.sum(output[i]).item()})")]
+                    w_boxes = torch.cat([boxes[i][x, :, :, :] for x in range(boxes[i].shape[0])], 2)
+                    train_wandb_bboxes += [wandb.Image(torchvision.transforms.ToPILImage()(w_boxes),
+                                                       caption=f"[E#{epoch}] {im_names[i]}")]
 
-                if i == 0:
-                    print(f'{data_iter_step}/{len(data_loader_train)}: loss: {loss_value},  pred_cnt: {pred_cnt},  gt_cnt: {gt_cnt},  error: {abs(pred_cnt - gt_cnt)},  AE: {cnt_err},  SE: {cnt_err ** 2}, {shot_num}-shot ')
+                for i in range(val_output.shape[0]):
+                    fig = torch.stack([val_output[i], black, black])
+                    f1 = torch.stack([val_gt_density[i], black, black])
+                    w_gt_density = val_samples[i] / 2 + f1
+                    w_d_map = fig
+                    w_d_map_overlay = val_samples[i] / 2 + fig
+                    w_densities = torch.cat([w_gt_density, w_d_map, w_d_map_overlay], dim=2)
+                    w_densities = torch.clamp(w_densities, 0, 1)
+                    val_wandb_densities += [wandb.Image(torchvision.transforms.ToPILImage()(w_densities),
+                                                        caption=f"[E#{epoch}] {val_im_names[i]} ({torch.sum(val_gt_density[i]).item()}, {torch.sum(val_output[i]).item()})")]
+                    w_boxes = torch.cat([val_boxes[i][x, :, :, :] for x in range(val_boxes[i].shape[0])], 2)
+                    val_wandb_bboxes += [wandb.Image(torchvision.transforms.ToPILImage()(w_boxes),
+                                                     caption=f"[E#{epoch}] {val_im_names[i]}")]
 
-            train_mae += batch_mae
-            train_rmse += batch_rmse
+                log = {"train/loss": loss_value_reduce,
+                       "train/lr": lr,
+                       "train/MAE": batch_mae,
+                       "train/RMSE": batch_mse ** 0.5,
+                       "val/MAE": val_mae / len(data_loader_val),
+                       "val/RMSE": (val_mse / len(data_loader_val)) ** 0.5,
+                       "val/NAE": val_nae / len(data_loader_val),
+                       "train_densitss": train_wandb_densities,
+                       "val_densites": val_wandb_densities,
+                       "train_boxes": train_wandb_bboxes,
+                       "val_boxes": val_wandb_bboxes}
+                wandb.log(log, step=idx)
 
-            # Output visualisation information to tensorboard
-            if data_iter_step == 0:
-                if log_writer is not None:
-                    fig = output[0].unsqueeze(0).repeat(3, 1, 1)
-                    f1 = gt_density[0].unsqueeze(0).repeat(3, 1, 1)
+            # save train status and model
+            if args.output_dir and (epoch % save_freq == 0 or epoch + 1 == args.epochs) and epoch != 0:
+                misc.save_model(
+                    args=args, model=model, model_without_ddp=model_without_ddp, optimizer=optimizer,
+                    loss_scaler=loss_scaler, epoch=epoch, suffix=f"finetuning_{epoch}", upload=epoch % 100 == 0)
+            elif True:
+                misc.save_model(
+                    args=args, model=model, model_without_ddp=model_without_ddp, optimizer=optimizer,
+                    loss_scaler=loss_scaler, epoch=epoch, suffix=f"finetuning_last", upload=False)
+            if args.output_dir and val_mae / len(data_loader_val) < min_MAE:
+                min_MAE = val_mae / len(data_loader_val)
+                misc.save_model(
+                    args=args, model=model, model_without_ddp=model_without_ddp, optimizer=optimizer,
+                    loss_scaler=loss_scaler, epoch=epoch, suffix="finetuning_minMAE")
 
-                    log_writer.add_images('bboxes', (boxes[0]), int(epoch), dataformats='NCHW')
-                    log_writer.add_images('gt_density', (samples[0] / 2 + f1 / 10), int(epoch), dataformats='CHW')
-                    log_writer.add_images('density map', (fig / 20), int(epoch), dataformats='CHW')
-                    log_writer.add_images('density map overlay', (samples[0] / 2 + fig / 10), int(epoch), dataformats='CHW')
+            print(f'[Train Epoch #{epoch}] - MAE: {train_mae.item() / len(data_loader_train):5.2f}, RMSE: {(train_mse.item() / len(data_loader_train)) ** 0.5:5.2f}', flush=True)
+            print(f'[Val Epoch #{epoch}] - MAE: {val_mae.item() / len(data_loader_val):5.2f}, RMSE: {(val_mse.item() / len(data_loader_val)) ** 0.5:5.2f}, NAE: {val_nae.item() / len(data_loader_val):5.2f}', flush=True)
 
-                if wandb_run is not None:
-                    wandb_bboxes = []
-                    wandb_densities = []
+        total_time = time.time() - start_time
+        total_time_str = str(datetime.timedelta(seconds=int(total_time)))
+        print('Training time {}'.format(total_time_str))
 
-                    for i in range(boxes.shape[0]):
-                        fig = output[i].unsqueeze(0).repeat(3, 1, 1)
-                        f1 = gt_density[i].unsqueeze(0).repeat(3, 1, 1)
-                        w_gt_density = samples[i] / 2 + f1 / 5
-                        w_d_map = fig / 10
-                        w_d_map_overlay = samples[i] / 2 + fig / 5
-                        w_boxes = torch.cat([boxes[i][x, :, :, :] for x in range(boxes[i].shape[0])], 2)
-                        w_densities = torch.cat([w_gt_density, w_d_map, w_d_map_overlay], dim=2)
-                        w_densities = misc.min_max(w_densities)
-                        wandb_bboxes += [wandb.Image(torchvision.transforms.ToPILImage()(w_boxes))]
-                        wandb_densities += [wandb.Image(torchvision.transforms.ToPILImage()(w_densities))]
-
-                    wandb.log({f"Bounding boxes": wandb_bboxes}, step=epoch_1000x, commit=False)
-                    wandb.log({f"Density predictions": wandb_densities}, step=epoch_1000x, commit=False)
-
-            if not math.isfinite(loss_value):
-                print("Loss is {}, stopping training".format(loss_value))
-                sys.exit(1)
-
-            loss /= accum_iter
-            loss_scaler(loss, optimizer, parameters=model.parameters(),
-                        update_grad=(data_iter_step + 1) % accum_iter == 0)
-            if (data_iter_step + 1) % accum_iter == 0:
-                optimizer.zero_grad()
-
-            torch.cuda.synchronize()
-
-            metric_logger.update(loss=loss_value)
-
-            lr = optimizer.param_groups[0]["lr"]
-            metric_logger.update(lr=lr)
-
-            loss_value_reduce = misc.all_reduce_mean(loss_value)
-            if (data_iter_step + 1) % accum_iter == 0:
-                if log_writer is not None:
-                    """ We use epoch_1000x as the x-axis in tensorboard.
-                    This calibrates different curves when batch size changes.
-                    """
-                    log_writer.add_scalar('train_loss', loss_value_reduce, epoch_1000x)
-                    log_writer.add_scalar('lr', lr, epoch_1000x)
-                    log_writer.add_scalar('MAE', batch_mae / args.batch_size, epoch_1000x)
-                    log_writer.add_scalar('RMSE', (batch_rmse / args.batch_size) ** 0.5, epoch_1000x)
-                if wandb_run is not None:
-                    log = {"train/loss": loss_value_reduce, "train/lr": lr,
-                           "train/MAE": batch_mae / args.batch_size,
-                           "train/RMSE": (batch_rmse / args.batch_size) ** 0.5}
-                    wandb.log(log, step=epoch_1000x, commit=True if data_iter_step == 0 else False)
-
-        # Only use 1 batches when overfitting
-        metric_logger.synchronize_between_processes()
-        print("Averaged stats:", metric_logger)
-        train_stats = {k: meter.global_avg for k, meter in metric_logger.meters.items()}
-
-        # save train status and model
-        if args.output_dir and (epoch % 50 == 0 or epoch + 1 == args.epochs):
-            misc.save_model(
-                args=args, model=model, model_without_ddp=model_without_ddp, optimizer=optimizer,
-                loss_scaler=loss_scaler, epoch=epoch, suffix=f"finetuning_{epoch}")
-        if args.output_dir and train_mae / (len(data_loader_train) * args.batch_size) < min_MAE:
-            min_MAE = train_mae / (len(data_loader_train) * args.batch_size)
-            misc.save_model(
-                args=args, model=model, model_without_ddp=model_without_ddp, optimizer=optimizer,
-                loss_scaler=loss_scaler, epoch=epoch, suffix="finetuning_minMAE")
-
-        # Output log status
-        log_stats = {**{f'train_{k}': v for k, v in train_stats.items()},
-                     'Current MAE': train_mae / (len(data_loader_train) * args.batch_size),
-                     'RMSE': (train_rmse / (len(data_loader_train) * args.batch_size)) ** 0.5,
-                     'epoch': epoch, }
-
-        print('Current MAE: {:5.2f}, RMSE: {:5.2f} '.format(train_mae / (len(data_loader_train) * args.batch_size), (
-                    train_rmse / (len(data_loader_train) * args.batch_size)) ** 0.5))
-
-        if args.output_dir and misc.is_main_process():
-            if log_writer is not None:
-                log_writer.flush()
-            with open(os.path.join(args.output_dir, "log.txt"), mode="a", encoding="utf-8") as f:
-                f.write(json.dumps(log_stats) + "\n")
-
-    total_time = time.time() - start_time
-    total_time_str = str(datetime.timedelta(seconds=int(total_time)))
-    print('Training time {}'.format(total_time_str))
-    wandb.run.finish()
+    finally:
+        if wandb_run is not None:
+            wandb.run.finish()
 
 
 if __name__ == '__main__':
     args = get_args_parser()
     args = args.parse_args()
 
-    # load data from FSC147
     data_path = Path(args.data_path)
     anno_file = data_path / args.anno_file
     data_split_file = data_path / args.data_split_file
     im_dir = data_path / args.im_dir
-    gt_dir = data_path / args.gt_dir
-    class_file = data_path / args.class_file
-    with open(anno_file) as f:
-        annotations = json.load(f)
-    with open(data_split_file) as f:
-        data_split = json.load(f)
-    class_dict = {}
-    with open(class_file) as f:
-        for line in f:
-            key = line.split()[0]
-            val = line.split()[1:]
-            class_dict[key] = val
+
+    if args.do_aug:
+        class_file = data_path / args.class_file
+    else:
+        class_file = None
+
+    args.anno_file = anno_file
+    args.data_split_file = data_split_file
+    args.im_dir = im_dir
+    args.class_file = class_file
 
     if args.output_dir:
         Path(args.output_dir).mkdir(parents=True, exist_ok=True)
+
     main(args)

--- a/demo_zero.py
+++ b/demo_zero.py
@@ -48,6 +48,7 @@ def run_one_image(samples, boxes, model, output_path, img_name, old_w, old_h):
     with measure_time() as et:
         with torch.no_grad():
             while start + 383 < w:
+                print("inference", start)
                 output, = model(samples[:, :, :, start:start + 384], boxes, shot_num)
                 output = output.squeeze(0)
                 b1 = nn.ZeroPad2d(padding=(start, w - prev - 1, 0, 0))
@@ -72,6 +73,8 @@ def run_one_image(samples, boxes, model, output_path, img_name, old_w, old_h):
                         start = w - 384
 
         pred_cnt = torch.sum(density_map / 60).item()
+
+    print("visualization")
 
     # Visualize the prediction
     fig = samples[0]
@@ -105,7 +108,7 @@ if __name__ == '__main__':
 
     checkpoint = torch.load(args.model_path, map_location='cpu')
     model_without_ddp.load_state_dict(checkpoint['model'], strict=False)
-    print("Resume checkpoint FSC147.pth")
+    print(f"Resume checkpoint {args.model_path}")
 
     model.eval()
 
@@ -123,4 +126,4 @@ if __name__ == '__main__':
         samples = samples.unsqueeze(0).to(device, non_blocking=True)
         boxes = boxes.unsqueeze(0).to(device, non_blocking=True)
         result, elapsed_time = run_one_image(samples, boxes, model, args.output_path, args.input_path.stem, old_w, old_h)
-        print(result, elapsed_time.duration)
+        print("Count:", result, "- Time:", elapsed_time.duration)

--- a/demo_zero.py
+++ b/demo_zero.py
@@ -1,0 +1,126 @@
+from itertools import chain
+from argparse import ArgumentParser
+from pathlib import Path
+
+from PIL import Image
+import torch
+import torch.nn as nn
+import torchvision
+from torchvision import transforms
+import timm
+import numpy as np
+from PIL import ImageDraw
+
+import models_mae_cross
+from util.misc import measure_time
+
+
+assert "0.4.5" <= timm.__version__ <= "0.4.9"  # version check
+device = torch.device('cuda')
+shot_num = 0
+
+
+def load_image(img_path: str):
+    image = Image.open(img_path).convert('RGB')
+    image.load()
+    W, H = image.size
+
+    # Resize the image size so that the height is 384
+    new_H = 384
+    new_W = 16 * int((W / H * 384) / 16)
+    image = transforms.Resize((new_H, new_W))(image)
+    Normalize = transforms.Compose([transforms.ToTensor()])
+    image = Normalize(image)
+
+    # Coordinates of the exemplar bound boxes
+    # Not needed for zero-shot counting
+    boxes = torch.Tensor([])
+    return image, boxes, W, H
+
+
+def run_one_image(samples, boxes, model, output_path, img_name, old_w, old_h):
+    _, _, h, w = samples.shape
+
+    density_map = torch.zeros([h, w])
+    density_map = density_map.to(device, non_blocking=True)
+    start = 0
+    prev = -1
+    with measure_time() as et:
+        with torch.no_grad():
+            while start + 383 < w:
+                output, = model(samples[:, :, :, start:start + 384], boxes, shot_num)
+                output = output.squeeze(0)
+                b1 = nn.ZeroPad2d(padding=(start, w - prev - 1, 0, 0))
+                d1 = b1(output[:, 0:prev - start + 1])
+                b2 = nn.ZeroPad2d(padding=(prev + 1, w - start - 384, 0, 0))
+                d2 = b2(output[:, prev - start + 1:384])
+
+                b3 = nn.ZeroPad2d(padding=(0, w - start, 0, 0))
+                density_map_l = b3(density_map[:, 0:start])
+                density_map_m = b1(density_map[:, start:prev + 1])
+                b4 = nn.ZeroPad2d(padding=(prev + 1, 0, 0, 0))
+                density_map_r = b4(density_map[:, prev + 1:w])
+
+                density_map = density_map_l + density_map_r + density_map_m / 2 + d1 / 2 + d2
+
+                prev = start + 383
+                start = start + 128
+                if start + 383 >= w:
+                    if start == w - 384 + 128:
+                        break
+                    else:
+                        start = w - 384
+
+        pred_cnt = torch.sum(density_map / 60).item()
+
+    # Visualize the prediction
+    fig = samples[0]
+    pred_fig = torch.stack((density_map, torch.zeros_like(density_map), torch.zeros_like(density_map)))
+    count_im = Image.new(mode="RGB", size=(w, h), color=(0, 0, 0))
+    draw = ImageDraw.Draw(count_im)
+    draw.text((w-70, h-50), f"{pred_cnt:.3f}", (255, 255, 255))
+    count_im = np.array(count_im).transpose((2, 0, 1))
+    count_im = torch.tensor(count_im, device=device)
+    fig = fig * 0.5 + pred_fig / 2 + count_im
+    fig = torch.clamp(fig, 0, 1)
+    fig = transforms.Resize((old_h, old_w))(fig)
+    torchvision.utils.save_image(fig, output_path / f'viz_{img_name}.jpg')
+    return pred_cnt, et
+
+
+if __name__ == '__main__':
+    # get parameters
+    p = ArgumentParser()
+    p.add_argument("--input_path", type=Path, required=True)
+    p.add_argument("--output_path", type=Path, default="results")
+    p.add_argument("--model_path", type=Path, default="weights\FSC147.pth")
+    args = p.parse_args()
+
+    args.output_path.mkdir(exist_ok=True, parents=True)
+
+    # Prepare model
+    model = models_mae_cross.__dict__['mae_vit_base_patch16'](norm_pix_loss='store_true')
+    model.to(device)
+    model_without_ddp = model
+
+    checkpoint = torch.load(args.model_path, map_location='cpu')
+    model_without_ddp.load_state_dict(checkpoint['model'], strict=False)
+    print("Resume checkpoint FSC147.pth")
+
+    model.eval()
+
+    # Test on the new image
+    if args.input_path.is_dir():
+        inputs = sorted(list(chain(args.input_path.glob("*.jpg"), args.input_path.glob("*.png"))))
+        for i, img_path in enumerate(inputs):
+            samples, boxes, old_w, old_h = load_image(img_path)
+            samples = samples.unsqueeze(0).to(device, non_blocking=True)
+            boxes = boxes.unsqueeze(0).to(device, non_blocking=True)
+            result, elapsed_time = run_one_image(samples, boxes, model, args.output_path, img_path.stem, old_w, old_h)
+            print(f"[{i+1: 3}/{len(inputs)}] {img_path.name}:\tcount = {result:5.2f}  -  time = {elapsed_time.duration:5.2f}")
+    else:
+        samples, boxes, old_w, old_h = load_image(args.input_path)
+        samples = samples.unsqueeze(0).to(device, non_blocking=True)
+        boxes = boxes.unsqueeze(0).to(device, non_blocking=True)
+        result, elapsed_time = run_one_image(samples, boxes, model, args.output_path, args.input_path.stem, old_w, old_h)
+        print(result, elapsed_time.duration)

--- a/demo_zero.py
+++ b/demo_zero.py
@@ -48,7 +48,6 @@ def run_one_image(samples, boxes, model, output_path, img_name, old_w, old_h):
     with measure_time() as et:
         with torch.no_grad():
             while start + 383 < w:
-                print("inference", start)
                 output, = model(samples[:, :, :, start:start + 384], boxes, shot_num)
                 output = output.squeeze(0)
                 b1 = nn.ZeroPad2d(padding=(start, w - prev - 1, 0, 0))
@@ -73,8 +72,6 @@ def run_one_image(samples, boxes, model, output_path, img_name, old_w, old_h):
                         start = w - 384
 
         pred_cnt = torch.sum(density_map / 60).item()
-
-    print("visualization")
 
     # Visualize the prediction
     fig = samples[0]

--- a/demo_zero.py
+++ b/demo_zero.py
@@ -81,7 +81,7 @@ def run_one_image(samples, boxes, model, output_path, img_name, old_w, old_h):
     draw.text((w-70, h-50), f"{pred_cnt:.3f}", (255, 255, 255))
     count_im = np.array(count_im).transpose((2, 0, 1))
     count_im = torch.tensor(count_im, device=device)
-    fig = fig * 0.5 + pred_fig / 2 + count_im
+    fig = fig / 2 + pred_fig / 2 + count_im
     fig = torch.clamp(fig, 0, 1)
     fig = transforms.Resize((old_h, old_w))(fig)
     torchvision.utils.save_image(fig, output_path / f'viz_{img_name}.jpg')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,15 @@
-torchvision>=0.14.0
-timm~=0.4.9
-numpy>=1.23.4
-scipy>=1.9.3
-imgaug>=0.4.0
-pillow>=9.2.0
-matplotlib>=3.5.3
-hub>=3.0.1
-pandas>=1.5.1
+--extra-index-url https://download.pytorch.org/whl/cu116
+
+torch==1.13.1+cu116
+torchvision==0.14.1+cu116
+timm==0.4.9
+numpy==1.23.4
+scipy==1.10.1
+imgaug==0.4.0
+pillow==9.3.0
+matplotlib==3.6.3
+hub==3.0.1
+pandas==1.5.2
+six==1.16.0
+wandb
+tqdm

--- a/run_minimal.MD
+++ b/run_minimal.MD
@@ -1,12 +1,12 @@
 
 Finetuning con data augmentation:
 ```
-python -W ignore FSC_finetune_cross.py --epochs 5 --batch_size 4 --lr 1e-5 --output_dir ./results/finetune_aug --title finetune_aug --resume .\weights\FSC147.pth --data_path .\data\fsc\ --anno_file annotations.json --data_split_file train_test_val.json --class_file images.txt --im_dir images --num_workers 4
+python -W ignore FSC_finetune_cross.py --epochs 5 --batch_size 4 --lr 1e-5 --output_dir ./results/finetune_aug --title minimal_finetune_aug --resume .\weights\FSC147.pth --data_path .\data\fsc\ --anno_file annotations.json --data_split_file train_test_val.json --class_file images.txt --im_dir images --num_workers 4
 ```
 
 Finetuning senza data augmentation:
 ```
-python -W ignore FSC_finetune_cross.py --epochs 5 --batch_size 4 --lr 1e-5 --output_dir ./results/finetune_noaug --title finetune_noaug --resume .\weights\FSC147.pth --data_path .\data\fsc\ --anno_file annotations.json --data_split_file train_test_val.json --class_file images.txt --im_dir images --num_workers 4 --no_do_aug
+python -W ignore FSC_finetune_cross.py --epochs 5 --batch_size 4 --lr 1e-5 --output_dir ./results/finetune_noaug --title minimal_finetune_noaug --resume .\weights\FSC147.pth --data_path .\data\fsc\ --anno_file annotations.json --data_split_file train_test_val.json --class_file images.txt --im_dir images --num_workers 4 --no_do_aug
 ```
 
 Zero shot demo (directory):
@@ -16,15 +16,18 @@ python demo_zero.py --input_path data/fsc/images --output_path results/demo_zero
 
 Test zero shot:
 ```
-...
+python 'FSC_test_cross(few-shot).py' --data_path data/fsc --anno_file annotations.json --data_split_file train_test_val.json --im_dir images --output_dir results/test_zero --resume weights/FSC147.pth --box_bound 0
 ```
 
 Test few shot:
 ```
-...
+python 'FSC_test_cross(few-shot).py' --data_path data/fsc --anno_file annotations.json --data_split_file train_test_val.json --im_dir images --output_dir results/test_few --resume weights/FSC147.pth --box_bound 3
 ```
 
 Test few shot external:
 ```
-...
+python 'FSC_test_cross(few-shot).py' --data_path data/fsc --anno_file annotations_ext.json --data_split_file train_test_val.json --im_dir images --output_dir results/test_ext_2 --resume weights/FSC147.pth --box_bound 5 --external
 ```
+
+W&B report:
+https://api.wandb.ai/links/giovanni-ficarra/ilxvm4to

--- a/run_minimal.MD
+++ b/run_minimal.MD
@@ -30,8 +30,7 @@ root
 +---img
 ¦       
 +---util
-¦           
-+---env
+¦
 +---weights
 ¦       FSC147.pth
 ¦       

--- a/run_minimal.MD
+++ b/run_minimal.MD
@@ -1,33 +1,125 @@
+# Instructions to run minimal examples of training and testing with CounTR
 
-Finetuning con data augmentation:
-```
-python -W ignore FSC_finetune_cross.py --epochs 5 --batch_size 4 --lr 1e-5 --output_dir ./results/finetune_aug --title minimal_finetune_aug --resume .\weights\FSC147.pth --data_path .\data\fsc\ --anno_file annotations.json --data_split_file train_test_val.json --class_file images.txt --im_dir images --num_workers 4
-```
+Here you can find a zip folder with data and weights used in the following examples and their results:
+https://drive.google.com/file/d/134ac1x381PsaC3Y6RFXQWzpmlSzaoc3X/view?usp=sharing.
 
-Finetuning senza data augmentation:
-```
-python -W ignore FSC_finetune_cross.py --epochs 5 --batch_size 4 --lr 1e-5 --output_dir ./results/finetune_noaug --title minimal_finetune_noaug --resume .\weights\FSC147.pth --data_path .\data\fsc\ --anno_file annotations.json --data_split_file train_test_val.json --class_file images.txt --im_dir images --num_workers 4 --no_do_aug
-```
+Here is the W&B report relative to the finetuning examples:
+https://api.wandb.ai/links/giovanni-ficarra/ilxvm4to.
 
-Zero shot demo (directory):
+This should be the resulting structure of the directory, extracting the files from the zip folder into the root of the repository:
+```
+root
+¦   .gitignore
+¦   FSC_finetune_CARPK.py
+¦   FSC_finetune_cross.py
+¦   FSC_pretrain.py
+¦   FSC_test_CARPK.py
+¦   FSC_test_cross(few-shot).py
+¦   FSC_test_cross(zero-shot).py
+¦   LICENSE
+¦   README.md
+¦   demo.py
+¦   models_crossvit.py
+¦   models_mae_cross.py
+¦   models_mae_noct.py
+¦   requirements.txt
+¦   run.sh
+¦   run_minimal.MD
+¦   demo_zero.py
+¦   
++---img
+¦       
++---util
+¦           
++---env
++---weights
+¦       FSC147.pth
+¦       
++---data
+¦   +---fsc
+¦   ¦   ¦   train_test_val.json
+¦   ¦   ¦   annotations.json
+¦   ¦   ¦   annotations_ext.json
+¦   ¦   ¦   images.txt
+¦   ¦   ¦   annotations_ext_noGT.json
+¦   ¦   ¦   
+¦   ¦   +---images
+¦       
++---results
+¦   +---demo_zero_dir
+¦   +---test_few
+¦   +---test_zero
+¦   +---test_ext_1
+¦   +---test_ext_2
+¦   +---test_ext_noGT
+```
+&nbsp;
+
+
+## Commands to run finetuning and testing in different fashions, based on the new and updated parameters
+
+### Finetuning with data augmentation
+
+The `--do_aug` parameter is by default `True`.
+```
+python -W ignore FSC_finetune_cross.py --epochs 5 --batch_size 4 --lr 1e-5 --output_dir results/finetune_aug --title minimal_finetune_aug --resume weights/FSC147.pth --data_path data/fsc/ --anno_file annotations.json --data_split_file train_test_val.json --class_file images.txt --im_dir images --num_workers 4
+```
+&nbsp;
+
+### Finetuning senza data augmentation
+
+With the `--no_do_aug` parameter you can disable data augmentation.
+```
+python -W ignore FSC_finetune_cross.py --epochs 5 --batch_size 4 --lr 1e-5 --output_dir results/finetune_noaug --title minimal_finetune_noaug --resume weights/FSC147.pth --data_path data/fsc/ --anno_file annotations.json --data_split_file train_test_val.json --class_file images.txt --im_dir images --num_workers 4 --no_do_aug
+```
+&nbsp;
+
+### Zero-shot demo
+
+With `demo_zero.py` you can test CounTR on your own data in an easy manner without providing any exemplar, just an input file or directory. Forr each input image, it will print the number of counted objects and the elapsed time.
+
+With a single file:
+```
+python demo_zero.py --input_path data/fsc/images/19.jpg --output_path results/demo_zero_file
+```
+&nbsp;
+
+With a directory:
 ```
 python demo_zero.py --input_path data/fsc/images --output_path results/demo_zero_dir
 ```
+&nbsp;
 
-Test zero shot:
+### Test zero-shot
 ```
 python 'FSC_test_cross(few-shot).py' --data_path data/fsc --anno_file annotations.json --data_split_file train_test_val.json --im_dir images --output_dir results/test_zero --resume weights/FSC147.pth --box_bound 0
 ```
+&nbsp;
 
-Test few shot:
+### Test few-shot
 ```
 python 'FSC_test_cross(few-shot).py' --data_path data/fsc --anno_file annotations.json --data_split_file train_test_val.json --im_dir images --output_dir results/test_few --resume weights/FSC147.pth --box_bound 3
 ```
+&nbsp;
 
-Test few shot external:
+### Test few-shot external
+
+Ext 1 - 3 exemplars from a single image:
+```
+python 'FSC_test_cross(few-shot).py' --data_path data/fsc --anno_file annotations_ext.json --data_split_file train_test_val.json --im_dir images --output_dir results/test_ext_1 --resume weights/FSC147.pth --box_bound 3 --external
+```
+&nbsp;
+
+Ext 2 - 5 exemplars from 3 images:
 ```
 python 'FSC_test_cross(few-shot).py' --data_path data/fsc --anno_file annotations_ext.json --data_split_file train_test_val.json --im_dir images --output_dir results/test_ext_2 --resume weights/FSC147.pth --box_bound 5 --external
 ```
+&nbsp;
 
-W&B report:
-https://api.wandb.ai/links/giovanni-ficarra/ilxvm4to
+### Test few shot external noGT
+
+Without providing the ground truth density maps:
+```
+python 'FSC_test_cross(few-shot).py' --data_path data/fsc --anno_file annotations_ext_noGT.json --data_split_file train_test_val.json --im_dir images --output_dir results/test_ext_noGT --resume weights/FSC147.pth --box_bound 3 --external
+```
+In this way the metrics won't be meaningful but it is possible to try the model on new images with 

--- a/run_minimal.MD
+++ b/run_minimal.MD
@@ -121,4 +121,45 @@ Without providing the ground truth density maps:
 ```
 python 'FSC_test_cross(few-shot).py' --data_path data/fsc --anno_file annotations_ext_noGT.json --data_split_file train_test_val.json --im_dir images --output_dir results/test_ext_noGT --resume weights/FSC147.pth --box_bound 3 --external
 ```
-In this way the metrics won't be meaningful but it is possible to try the model on new images with 
+In this way the metrics won't be meaningful but it is possible to try the model on new images without the need of labeling them. That is, like similarly to `demo_zero.py`, but you can provide exemplars in the json annotations file.
+
+&nbsp;
+
+
+### Plot test results
+
+1. Install libraries needed for the plots, possibly in a virual environment:
+    ```
+    pip install plotly
+    pip install kaleido==0.1.0.post1
+    ```
+    (other versions of kaleido may work for you, this is what I tested)
+
+2. Go to the `util` directory and launch your Python interpreter:
+    ```bash
+    cd util
+    python
+    ```
+
+3. From within Python:
+    ```python
+    import misc
+    misc.log_test_results("../results")
+    misc.plot_test_results("../results")
+    ```
+
+The resulting plot, saved in the same directory as the results (in our case, `../results`), shows the performance of CounTR according to the three logged metrics (MAE, RMSE, NAE) along the whole set of experiments. It is particularly useful if your experiments are ordered (e.g., you test your model at different steps along the training, or after some modification you applied).
+
+Note that I removed `test_ext_noGT` from the results used for the plot, since without the ground truth the metrics cannot be meaningful.
+
+&nbsp;
+
+
+### Make a video from the output of the demo
+
+Steps 1 and 2 are the same as the previous example, then:
+
+```python
+import misc
+misc.frames2vid("../results/demo_zero_dir", "../results/demo.mp4", "viz*.jpg", 3)
+```

--- a/run_minimal.MD
+++ b/run_minimal.MD
@@ -1,0 +1,30 @@
+
+Finetuning con data augmentation:
+```
+python -W ignore FSC_finetune_cross.py --epochs 5 --batch_size 4 --lr 1e-5 --output_dir ./results/finetune_aug --title finetune_aug --resume .\weights\FSC147.pth --data_path .\data\fsc\ --anno_file annotations.json --data_split_file train_test_val.json --class_file images.txt --im_dir images --num_workers 4
+```
+
+Finetuning senza data augmentation:
+```
+python -W ignore FSC_finetune_cross.py --epochs 5 --batch_size 4 --lr 1e-5 --output_dir ./results/finetune_noaug --title finetune_noaug --resume .\weights\FSC147.pth --data_path .\data\fsc\ --anno_file annotations.json --data_split_file train_test_val.json --class_file images.txt --im_dir images --num_workers 4 --no_do_aug
+```
+
+Zero shot demo (directory):
+```
+python demo_zero.py --input_path data/fsc/images --output_path results/demo_zero_dir
+```
+
+Test zero shot:
+```
+...
+```
+
+Test few shot:
+```
+...
+```
+
+Test few shot external:
+```
+...
+```

--- a/run_minimal.MD
+++ b/run_minimal.MD
@@ -3,7 +3,7 @@
 Here you can find a zip folder with data and weights used in the following examples and their results:
 https://drive.google.com/file/d/134ac1x381PsaC3Y6RFXQWzpmlSzaoc3X/view?usp=sharing.
 
-Here is the W&B report relative to the finetuning examples:
+Here is the W&B report relative to the fine-tuning examples:
 https://api.wandb.ai/links/giovanni-ficarra/ilxvm4to.
 
 This should be the resulting structure of the directory, extracting the files from the zip folder into the root of the repository:
@@ -55,9 +55,9 @@ root
 &nbsp;
 
 
-## Commands to run finetuning and testing in different fashions, based on the new and updated parameters
+## Commands to run fine-tuning and testing in different fashions, based on the new and updated parameters
 
-### Finetuning with data augmentation
+### Fine-tuning with data augmentation
 
 The `--do_aug` parameter is by default `True`.
 ```
@@ -65,7 +65,7 @@ python -W ignore FSC_finetune_cross.py --epochs 5 --batch_size 4 --lr 1e-5 --out
 ```
 &nbsp;
 
-### Finetuning senza data augmentation
+### Fine-tuning without data augmentation
 
 With the `--no_do_aug` parameter you can disable data augmentation.
 ```
@@ -75,7 +75,7 @@ python -W ignore FSC_finetune_cross.py --epochs 5 --batch_size 4 --lr 1e-5 --out
 
 ### Zero-shot demo
 
-With `demo_zero.py` you can test CounTR on your own data in an easy manner without providing any exemplar, just an input file or directory. Forr each input image, it will print the number of counted objects and the elapsed time.
+With `demo_zero.py` you can test CounTR on your own data in an easy manner without providing any exemplar, just an input file or directory. For each input image, it will print the number of counted objects and the elapsed time.
 
 With a single file:
 ```
@@ -128,7 +128,7 @@ In this way the metrics won't be meaningful but it is possible to try the model 
 
 ### Plot test results
 
-1. Install libraries needed for the plots, possibly in a virual environment:
+1. Install libraries needed for the plots, possibly in a virtual environment:
     ```
     pip install plotly
     pip install kaleido==0.1.0.post1
@@ -163,3 +163,5 @@ Steps 1 and 2 are the same as the previous example, then:
 import misc
 misc.frames2vid("../results/demo_zero_dir", "../results/demo.mp4", "viz*.jpg", 3)
 ```
+
+It is particularly useful if you are testing CounTR on a sequence of frames.

--- a/util/FSC147.py
+++ b/util/FSC147.py
@@ -1,3 +1,4 @@
+from argparse import Namespace
 import json
 from pathlib import Path
 
@@ -19,11 +20,10 @@ IM_NORM_STD = [0.229, 0.224, 0.225]
 
 
 class ResizeSomeImage(object):
-    def __init__(self, data_path=Path('./data/FSC147/')):
-        self.im_dir = data_path / 'images_384_VarV2'
-        anno_file = data_path / 'annotation_FSC147_384.json'
-        data_split_file = data_path / 'Train_Test_Val_FSC_147.json'
-        class_file = data_path / 'ImageClasses_FSC147.txt'
+    def __init__(self, args):
+        self.im_dir = args.im_dir
+        anno_file = args.anno_file
+        data_split_file = args.data_split_file
 
         with open(anno_file) as f:
             self.annotations = json.load(f)
@@ -31,13 +31,15 @@ class ResizeSomeImage(object):
         with open(data_split_file) as f:
             data_split = json.load(f)
 
-        self.class_dict = {}
-        with open(class_file) as f:
-            for line in f:
-                key = line.split()[0]
-                val = line.split()[1:]
-                self.class_dict[key] = val
         self.train_set = data_split['train']
+
+        self.class_dict = {}
+        if args.do_aug:
+            with open(args.class_file) as f:
+                for line in f:
+                    key = line.split()[0]
+                    val = line.split()[1:]
+                    self.class_dict[key] = val
 
 
 class ResizePreTrainImage(ResizeSomeImage):
@@ -49,8 +51,8 @@ class ResizePreTrainImage(ResizeSomeImage):
     Density and boxes correctness not preserved(crop and horizontal flip)
     """
 
-    def __init__(self, data_path=Path('./data/FSC147/'), MAX_HW=384):
-        super().__init__(data_path)
+    def __init__(self, args, MAX_HW=384):
+        super().__init__(args)
         self.max_hw = MAX_HW
 
     def __call__(self, sample):
@@ -60,9 +62,6 @@ class ResizePreTrainImage(ResizeSomeImage):
 
         new_H = 16 * int(H / 16)
         new_W = 16 * int(W / 16)
-        '''scale_factor = float(256)/ H
-        new_H = 16*int(H*scale_factor/16)
-        new_W = 16*int(W*scale_factor/16)'''
         resized_image = transforms.Resize((new_H, new_W))(image)
         resized_density = cv2.resize(density, (new_W, new_H))
         orig_count = np.sum(density)
@@ -95,50 +94,44 @@ class ResizeTrainImage(ResizeSomeImage):
     Augmentation including Gaussian noise, Color jitter, Gaussian blur, Random affine, Random horizontal flip and Mosaic (or Random Crop if no Mosaic) is used.
     """
 
-    def __init__(self, data_path=Path('./data/FSC147/'), MAX_HW=384):
-        super().__init__(data_path)
+    def __init__(self, args, MAX_HW=384, do_aug=True):
+        super().__init__(args)
         self.max_hw = MAX_HW
+        self.do_aug = do_aug
 
     def __call__(self, sample):
-        image, lines_boxes, density, dots, im_id, m_flag = sample['image'], sample['lines_boxes'], sample['gt_density'], \
+        image, lines_boxes, dots, im_id, m_flag = sample['image'], sample['lines_boxes'], \
             sample['dots'], sample['id'], sample['m_flag']
 
         W, H = image.size
 
         new_H = 16 * int(H / 16)
         new_W = 16 * int(W / 16)
-        scale_factor = float(new_W) / W
+        scale_factor_h = float(new_H) / H
+        scale_factor_w = float(new_W) / W
         resized_image = transforms.Resize((new_H, new_W))(image)
-        resized_density = cv2.resize(density, (new_W, new_H))
+        resized_image = TTensor(resized_image)
+        resized_density = np.zeros((new_H, new_W), dtype='float32')
 
         # Augmentation probability
-        aug_p = random.random()
-        aug_flag = 0
-        mosaic_flag = 0
-        if aug_p < 0.4:  # 0.4
-            aug_flag = 1
-            if aug_p < 0.25:  # 0.25
-                aug_flag = 0
-                mosaic_flag = 1
+        aug_flag = self.do_aug
+        mosaic_flag = random.random() < 0.25
 
-        # Gaussian noise
-        resized_image = TTensor(resized_image)
-        if aug_flag == 1:
+        if aug_flag:
+            # Gaussian noise
             noise = np.random.normal(0, 0.1, resized_image.size())
             noise = torch.from_numpy(noise)
             re_image = resized_image + noise
             re_image = torch.clamp(re_image, 0, 1)
 
-        # Color jitter and Gaussian blur
-        if aug_flag == 1:
+            # Color jitter and Gaussian blur
             re_image = Augmentation(re_image)
 
-        # Random affine
-        if aug_flag == 1:
+            # Random affine
             re1_image = re_image.transpose(0, 1).transpose(1, 2).numpy()
             keypoints = []
             for i in range(dots.shape[0]):
-                keypoints.append(Keypoint(x=min(new_W - 1, int(dots[i][0] * scale_factor)), y=min(new_H - 1, int(dots[i][1]))))
+                keypoints.append(Keypoint(x=min(new_W - 1, int(dots[i][0] * scale_factor_w)), y=min(new_H - 1, int(dots[i][1] * scale_factor_h))))
             kps = KeypointsOnImage(keypoints, re1_image.shape)
 
             seq = iaa.Sequential([
@@ -161,107 +154,109 @@ class ResizeTrainImage(ResizeSomeImage):
 
             re_image = TTensor(re1_image)
 
-        # Random horizontal flip
-        if aug_flag == 1:
+            # Random horizontal flip
             flip_p = random.random()
             if flip_p > 0.5:
                 re_image = TF.hflip(re_image)
-                resized_density = TF.hflip(resized_density)
+                resized_density = TF.hflip(resized_density)    
 
-        # Random 384*384 crop in a new_W*384 image and 384*new_W density map
-        if mosaic_flag == 0:
-            if aug_flag == 0:
-                re_image = resized_image
-                resized_density = np.zeros((resized_density.shape[0], resized_density.shape[1]), dtype='float32')
-                for i in range(dots.shape[0]):
-                    resized_density[min(new_H - 1, int(dots[i][1]))][min(new_W - 1, int(dots[i][0] * scale_factor))] = 1
-                resized_density = torch.from_numpy(resized_density)
-
-            start = random.randint(0, new_W - 1 - 383)
-            reresized_image = TF.crop(re_image, 0, start, 384, 384)
-            reresized_density = resized_density[:, start:start + 384]
-        # Random self mosaic
-        else:
-            image_array = []
-            map_array = []
-            blending_l = random.randint(10, 20)
-            resize_l = 192 + 2 * blending_l
-            if dots.shape[0] >= 70:
-                for i in range(4):
-                    length = random.randint(150, 384)
-                    start_W = random.randint(0, new_W - length)
-                    start_H = random.randint(0, new_H - length)
-                    reresized_image1 = TF.crop(resized_image, start_H, start_W, length, length)
-                    reresized_image1 = transforms.Resize((resize_l, resize_l))(reresized_image1)
-                    reresized_density1 = np.zeros((resize_l, resize_l), dtype='float32')
-                    for i in range(dots.shape[0]):
-                        if start_H <= min(new_H - 1, int(dots[i][1])) < start_H + length and start_W <= min(new_W - 1, int(dots[i][0] * scale_factor)) < start_W + length:
-                            reresized_density1[min(resize_l-1,int((min(new_H-1,int(dots[i][1]))-start_H)*resize_l/length))][min(resize_l-1,int((min(new_W-1,int(dots[i][0]*scale_factor))-start_W)*resize_l/length))]=1
-                    reresized_density1 = torch.from_numpy(reresized_density1)
-                    image_array.append(reresized_image1)
-                    map_array.append(reresized_density1)
-            else:
-                m_flag = 1
-                prob = random.random()
-                if prob > 0.25:
-                    gt_pos = random.randint(0, 3)
+            # Random self mosaic
+            if mosaic_flag:
+                image_array = []
+                map_array = []
+                blending_l = random.randint(10, 20)
+                resize_l = 192 + 2 * blending_l
+                if dots.shape[0] >= 70:
+                    for i in range(4):
+                        length = random.randint(150, 384)
+                        start_W = random.randint(0, new_W - length)
+                        start_H = random.randint(0, new_H - length)
+                        reresized_image1 = TF.crop(resized_image, start_H, start_W, length, length)
+                        reresized_image1 = transforms.Resize((resize_l, resize_l))(reresized_image1)
+                        reresized_density1 = np.zeros((resize_l, resize_l), dtype='float32')
+                        for i in range(dots.shape[0]):
+                            if start_H <= min(new_H - 1, int(dots[i][1] * scale_factor_h)) < start_H + length and start_W <= min(new_W - 1, int(dots[i][0] * scale_factor_w)) < start_W + length:
+                                reresized_density1[min(resize_l-1,int((min(new_H-1,int(dots[i][1] * scale_factor_h))-start_H)*resize_l/length))][min(resize_l-1,int((min(new_W-1,int(dots[i][0] * scale_factor_w))-start_W)*resize_l/length))]=1
+                        reresized_density1 = torch.from_numpy(reresized_density1)
+                        image_array.append(reresized_image1)
+                        map_array.append(reresized_density1)
                 else:
-                    gt_pos = random.randint(0, 4)  # 5% 0 objects
-                for i in range(4):
-                    if i == gt_pos:
-                        Tim_id = im_id
-                        r_image = resized_image
-                        Tdots = dots
-                        new_TH = new_H
-                        new_TW = new_W
-                        Tscale_factor = scale_factor
+                    m_flag = 1
+                    prob = random.random()
+                    if prob > 0.25:
+                        gt_pos = random.randint(0, 3)
                     else:
-                        Tim_id = self.train_set[random.randint(0, len(self.train_set) - 1)]
-                        Tdots = np.array(self.annotations[Tim_id]['points'])
-                        '''while(abs(Tdots.shape[0]-dots.shape[0]<=10)):
-                            Tim_id = train_set[random.randint(0, len(train_set)-1)]
-                            Tdots = np.array(annotations[Tim_id]['points'])'''
-                        Timage = Image.open('{}/{}'.format(self.im_dir, Tim_id))
-                        Timage.load()
-                        new_TH = 16 * int(Timage.size[1] / 16)
-                        new_TW = 16 * int(Timage.size[0] / 16)
-                        Tscale_factor = float(new_TW) / Timage.size[0]
-                        r_image = TTensor(transforms.Resize((new_TH, new_TW))(Timage))
+                        gt_pos = random.randint(0, 4)  # 5% 0 objects
+                    for i in range(4):
+                        if i == gt_pos:
+                            Tim_id = im_id
+                            r_image = resized_image
+                            Tdots = dots
+                            new_TH = new_H
+                            new_TW = new_W
+                            Tscale_factor_w = scale_factor_w
+                            Tscale_factor_h = scale_factor_h
+                        else:
+                            Tim_id = self.train_set[random.randint(0, len(self.train_set) - 1)]
+                            Tdots = np.array(self.annotations[Tim_id]['points'])
+                            Timage = Image.open('{}/{}'.format(self.im_dir, Tim_id))
+                            Timage.load()
+                            new_TW = 16 * int(Timage.size[0] / 16)
+                            new_TH = 16 * int(Timage.size[1] / 16)
+                            Tscale_factor_w = float(new_TW) / Timage.size[0]
+                            Tscale_factor_h = float(new_TH) / Timage.size[1]
+                            r_image = TTensor(transforms.Resize((new_TH, new_TW))(Timage))
 
-                    length = random.randint(250, 384)
-                    start_W = random.randint(0, new_TW - length)
-                    start_H = random.randint(0, new_TH - length)
-                    r_image1 = TF.crop(r_image, start_H, start_W, length, length)
-                    r_image1 = transforms.Resize((resize_l, resize_l))(r_image1)
-                    r_density1 = np.zeros((resize_l, resize_l), dtype='float32')
-                    if self.class_dict[im_id] == self.class_dict[Tim_id]:
-                        for i in range(Tdots.shape[0]):
-                            if start_H <= min(new_TH - 1, int(Tdots[i][1])) < start_H + length and start_W <= min(new_TW - 1, int(Tdots[i][0] * Tscale_factor)) < start_W + length:
-                                r_density1[min(resize_l-1,int((min(new_TH-1,int(Tdots[i][1]))-start_H)*resize_l/length))][min(resize_l-1,int((min(new_TW-1,int(Tdots[i][0]*Tscale_factor))-start_W)*resize_l/length))]=1
-                    r_density1 = torch.from_numpy(r_density1)
-                    image_array.append(r_image1)
-                    map_array.append(r_density1)
+                        length = random.randint(250, 384)
+                        start_W = random.randint(0, new_TW - length)
+                        start_H = random.randint(0, new_TH - length)
+                        r_image1 = TF.crop(r_image, start_H, start_W, length, length)
+                        r_image1 = transforms.Resize((resize_l, resize_l))(r_image1)
+                        r_density1 = np.zeros((resize_l, resize_l), dtype='float32')
+                        if self.class_dict[im_id] == self.class_dict[Tim_id]:
+                            for i in range(Tdots.shape[0]):
+                                if start_H <= min(new_TH - 1, int(Tdots[i][1] * Tscale_factor_h)) < start_H + length and start_W <= min(new_TW - 1, int(Tdots[i][0] * Tscale_factor_w)) < start_W + length:
+                                    r_density1[min(resize_l-1,int((min(new_TH-1, int(Tdots[i][1] * Tscale_factor_h))-start_H)*resize_l/length))][min(resize_l-1,int((min(new_TW-1,int(Tdots[i][0] * Tscale_factor_w))-start_W)*resize_l/length))]=1
+                        r_density1 = torch.from_numpy(r_density1)
+                        image_array.append(r_image1)
+                        map_array.append(r_density1)
 
-            reresized_image5 = torch.cat((image_array[0][:, blending_l:resize_l-blending_l], image_array[1][:, blending_l: resize_l-blending_l]), 1)
-            reresized_density5 = torch.cat((map_array[0][blending_l:resize_l-blending_l], map_array[1][blending_l: resize_l-blending_l]), 0)
-            for i in range(blending_l):
-                    reresized_image5[:, 192+i] = image_array[0][:, resize_l-1-blending_l+i] * (blending_l-i)/(2 * blending_l) + reresized_image5[:, 192+i] * (i+blending_l)/(2*blending_l)
-                    reresized_image5[:, 191-i] = image_array[1][:, blending_l-i] * (blending_l-i)/(2*blending_l) + reresized_image5[:, 191-i] * (i+blending_l)/(2*blending_l)
-            reresized_image5 = torch.clamp(reresized_image5, 0, 1)
+                reresized_image5 = torch.cat((image_array[0][:, blending_l:resize_l-blending_l], image_array[1][:, blending_l: resize_l-blending_l]), 1)
+                reresized_density5 = torch.cat((map_array[0][blending_l:resize_l-blending_l], map_array[1][blending_l: resize_l-blending_l]), 0)
+                for i in range(blending_l):
+                        reresized_image5[:, 192+i] = image_array[0][:, resize_l-1-blending_l+i] * (blending_l-i)/(2 * blending_l) + reresized_image5[:, 192+i] * (i+blending_l)/(2*blending_l)
+                        reresized_image5[:, 191-i] = image_array[1][:, blending_l-i] * (blending_l-i)/(2*blending_l) + reresized_image5[:, 191-i] * (i+blending_l)/(2*blending_l)
+                reresized_image5 = torch.clamp(reresized_image5, 0, 1)
 
-            reresized_image6 = torch.cat((image_array[2][:, blending_l:resize_l-blending_l], image_array[3][:, blending_l: resize_l-blending_l]), 1)
-            reresized_density6 = torch.cat((map_array[2][blending_l:resize_l-blending_l], map_array[3][blending_l:resize_l-blending_l]), 0)
-            for i in range(blending_l):
-                    reresized_image6[:, 192+i] = image_array[2][:, resize_l-1-blending_l+i] * (blending_l-i)/(2*blending_l) + reresized_image6[:, 192+i] * (i+blending_l)/(2*blending_l)
-                    reresized_image6[:, 191-i] = image_array[3][:, blending_l-i] * (blending_l-i)/(2*blending_l) + reresized_image6[:, 191-i] * (i+blending_l)/(2*blending_l)
-            reresized_image6 = torch.clamp(reresized_image6, 0, 1)
+                reresized_image6 = torch.cat((image_array[2][:, blending_l:resize_l-blending_l], image_array[3][:, blending_l: resize_l-blending_l]), 1)
+                reresized_density6 = torch.cat((map_array[2][blending_l:resize_l-blending_l], map_array[3][blending_l:resize_l-blending_l]), 0)
+                for i in range(blending_l):
+                        reresized_image6[:, 192+i] = image_array[2][:, resize_l-1-blending_l+i] * (blending_l-i)/(2*blending_l) + reresized_image6[:, 192+i] * (i+blending_l)/(2*blending_l)
+                        reresized_image6[:, 191-i] = image_array[3][:, blending_l-i] * (blending_l-i)/(2*blending_l) + reresized_image6[:, 191-i] * (i+blending_l)/(2*blending_l)
+                reresized_image6 = torch.clamp(reresized_image6, 0, 1)
 
-            reresized_image = torch.cat((reresized_image5[:, :, blending_l:resize_l-blending_l], reresized_image6[:, :, blending_l:resize_l-blending_l]), 2)
-            reresized_density = torch.cat((reresized_density5[:, blending_l:resize_l-blending_l], reresized_density6[:, blending_l:resize_l-blending_l]), 1)
-            for i in range(blending_l):
-                    reresized_image[:, :, 192+i] = reresized_image5[:, :, resize_l-1-blending_l+i] * (blending_l-i)/(2*blending_l) + reresized_image[:, :, 192+i] * (i+blending_l)/(2*blending_l)
-                    reresized_image[:, :, 191-i] = reresized_image6[:, :, blending_l-i] * (blending_l-i)/(2*blending_l) + reresized_image[:, :, 191-i] * (i+blending_l)/(2*blending_l)
-            reresized_image = torch.clamp(reresized_image, 0, 1)
+                reresized_image = torch.cat((reresized_image5[:, :, blending_l:resize_l-blending_l], reresized_image6[:, :, blending_l:resize_l-blending_l]), 2)
+                reresized_density = torch.cat((reresized_density5[:, blending_l:resize_l-blending_l], reresized_density6[:, blending_l:resize_l-blending_l]), 1)
+                for i in range(blending_l):
+                        reresized_image[:, :, 192+i] = reresized_image5[:, :, resize_l-1-blending_l+i] * (blending_l-i)/(2*blending_l) + reresized_image[:, :, 192+i] * (i+blending_l)/(2*blending_l)
+                        reresized_image[:, :, 191-i] = reresized_image6[:, :, blending_l-i] * (blending_l-i)/(2*blending_l) + reresized_image[:, :, 191-i] * (i+blending_l)/(2*blending_l)
+                reresized_image = torch.clamp(reresized_image, 0, 1)
+
+            else:
+                # Random 384*384 crop in a new_W*384 image and 384*new_W density map
+                start = random.randint(0, new_W - 1 - 383)
+                reresized_image = TF.crop(re_image, 0, start, 384, 384)
+                reresized_density = resized_density[:, start:start + 384]
+
+        else:
+            # Random 384*384 crop in a new_W*384 image and 384*new_W density map
+            for i in range(dots.shape[0]):
+                resized_density[min(new_H - 1, int(dots[i][1] * scale_factor_h))] \
+                                [min(new_W - 1, int(dots[i][0] * scale_factor_w))] = 1
+            resized_density = torch.from_numpy(resized_density)
+            start = random.randint(0, new_W - self.max_hw)
+            reresized_image = TF.crop(resized_image, 0, start, self.max_hw, self.max_hw)
+            reresized_density = resized_density[0:self.max_hw, start:start + self.max_hw]
 
         # Gaussian distribution density map
         reresized_density = ndimage.gaussian_filter(reresized_density.numpy(), sigma=(1, 1), order=0)
@@ -278,12 +273,14 @@ class ResizeTrainImage(ResizeSomeImage):
             if cnt > 3:
                 break
             box2 = [int(k) for k in box]
-            y1, x1, y2, x2 = box2[0], int(box2[1] * scale_factor), box2[2], int(box2[3] * scale_factor)
+            y1 = int(box2[0] * scale_factor_h)
+            x1 = int(box2[1] * scale_factor_w)
+            y2 = int(box2[2] * scale_factor_h)
+            x2 = int(box2[3] * scale_factor_w)
             bbox = resized_image[:, y1:y2 + 1, x1:x2 + 1]
             bbox = transforms.Resize((64, 64))(bbox)
-            boxes.append(bbox.numpy())
-        boxes = np.array(boxes)
-        boxes = torch.Tensor(boxes)
+            boxes.append(bbox)
+        boxes = torch.stack(boxes)
 
         # boxes shape [3,3,64,64], image shape [3,384,384], density shape[384,384]
         sample = {'image': reresized_image, 'boxes': boxes, 'gt_density': reresized_density, 'm_flag': m_flag}
@@ -291,8 +288,54 @@ class ResizeTrainImage(ResizeSomeImage):
         return sample
 
 
+class ResizeValImage(ResizeSomeImage):
+    def __init__(self, args, MAX_HW=384):
+        super().__init__(args)
+        self.max_hw = MAX_HW
+
+    def __call__(self, sample):
+        image, dots, m_flag, lines_boxes = sample['image'], sample['dots'], sample['m_flag'], sample['lines_boxes']
+
+        W, H = image.size
+
+        new_H = new_W = self.max_hw
+        scale_factor_h = float(new_H) / H
+        scale_factor_w = float(new_W) / W
+        resized_image = transforms.Resize((new_H, new_W))(image)
+        resized_image = TTensor(resized_image)
+
+        # Resize density map
+        resized_density = np.zeros((new_H, new_W), dtype='float32')
+        for i in range(dots.shape[0]):
+            resized_density[min(new_H - 1, int(dots[i][1] * scale_factor_h))] \
+                           [min(new_W - 1, int(dots[i][0] * scale_factor_w))] = 1
+        resized_density = ndimage.gaussian_filter(resized_density, sigma=4, radius=7, order=0)
+        resized_density = torch.from_numpy(resized_density) * 60
+
+        # Crop bboxes and resize as 64x64
+        boxes = list()
+        cnt = 0
+        for box in lines_boxes:
+            cnt += 1
+            if cnt > 3:
+                break
+            box2 = [int(k) for k in box]
+            y1 = int(box2[0] * scale_factor_h)
+            x1 = int(box2[1] * scale_factor_w)
+            y2 = int(box2[2] * scale_factor_h)
+            x2 = int(box2[3] * scale_factor_w)
+            bbox = resized_image[:, y1:y2 + 1, x1:x2 + 1]
+            bbox = transforms.Resize((64, 64))(bbox)
+            boxes.append(bbox)
+        boxes = torch.stack(boxes)
+
+        # boxes shape [3,3,64,64], image shape [3,384,384], density shape[384,384]
+        sample = {'image': resized_image, 'boxes': boxes, 'gt_density': resized_density, 'm_flag': m_flag}
+        return sample
+
+
 PreTrainNormalize = transforms.Compose([
-    transforms.RandomResizedCrop(384, scale=(0.2, 1.0), interpolation=3),
+    transforms.RandomResizedCrop(MAX_HW, scale=(0.2, 1.0), interpolation=3),
     transforms.RandomHorizontalFlip(),
     transforms.ToTensor(),
     # transforms.Normalize(mean=IM_NORM_MEAN, std=IM_NORM_STD)
@@ -313,9 +356,11 @@ Normalize = transforms.Compose([
 ])
 
 
-def transform_train(data_path: Path):
-    return transforms.Compose([ResizeTrainImage(data_path, MAX_HW)])
+def transform_train(args: Namespace, do_aug=True):
+    return transforms.Compose([ResizeTrainImage(args, MAX_HW, do_aug)])
 
+def transform_val(args: Namespace):
+    return transforms.Compose([ResizeValImage(args, MAX_HW)])
 
-def transform_pre_train(data_path: Path):
-    return transforms.Compose([ResizePreTrainImage(data_path, MAX_HW)])
+def transform_pre_train(args: Namespace):
+    return transforms.Compose([ResizePreTrainImage(args, MAX_HW)])

--- a/util/misc.py
+++ b/util/misc.py
@@ -603,7 +603,7 @@ def plot_test_results(test_dir):
     fig.write_html(test_dir / "plot.html", auto_open=False)
 
 
-def frames_to_video(input_dir: str, output_file: str, pattern: str, fps: int):
+def frames2vid(input_dir: str, output_file: str, pattern: str, fps: int):
     input_dir = Path(input_dir)
     video_file = None
     files = list(input_dir.glob(pattern))

--- a/util/misc.py
+++ b/util/misc.py
@@ -25,6 +25,9 @@ import wandb
 from torch._six import inf
 import matplotlib.pyplot as plt
 from torchvision import transforms
+import cv2
+from tqdm import tqdm
+
 
 class SmoothedValue(object):
     """Track a series of values and provide access to smoothed values over a
@@ -543,9 +546,6 @@ def log_test_results(test_dir):
     cols = list(df.columns)
     cols = cols[-1:] + cols[:-1]
     df = df[cols]
-    # idx = df.index.tolist()
-    # idx.pop(0)
-    # df = df.reindex(idx+[0])
 
     df.to_csv(test_dir / "logs.csv", index=False)
 
@@ -601,3 +601,17 @@ def plot_test_results(test_dir):
     fig.update_yaxes(type="log")
     fig.write_image(test_dir / "plot.jpeg", scale=4)
     fig.write_html(test_dir / "plot.html", auto_open=False)
+
+
+def frames_to_video(input_dir: str, output_file: str, pattern: str, fps: int):
+    input_dir = Path(input_dir)
+    video_file = None
+    files = list(input_dir.glob(pattern))
+    for i, img in enumerate(tqdm(files, total=len(files))):
+        frame = cv2.imread(str(img))
+        if i == 0:
+            h, w, _ = frame.shape
+            video_file = cv2.VideoWriter(output_file, cv2.VideoWriter_fourcc(*'mp4v'), fps, (w, h))
+        video_file.write(frame)
+
+    video_file.release()

--- a/util/misc.py
+++ b/util/misc.py
@@ -13,20 +13,18 @@ import builtins
 import datetime
 import os
 import time
+import json
 from collections import defaultdict, deque
 from pathlib import Path
 from typing import Union
 
-import numpy as np
 import pandas as pd
 import torch
 import torch.distributed as dist
 import wandb
 from torch._six import inf
-import timm
 import matplotlib.pyplot as plt
 from torchvision import transforms
-
 
 class SmoothedValue(object):
     """Track a series of values and provide access to smoothed values over a
@@ -299,7 +297,7 @@ def get_grad_norm_(parameters, norm_type: float = 2.0) -> torch.Tensor:
     return total_norm
 
 
-def save_model(args, epoch, model, model_without_ddp, optimizer, loss_scaler, suffix=""):
+def save_model(args, epoch, model, model_without_ddp, optimizer, loss_scaler, suffix="", upload=True):
     if suffix:
         suffix = f"__{suffix}"
     output_dir = Path(args.output_dir)
@@ -315,12 +313,14 @@ def save_model(args, epoch, model, model_without_ddp, optimizer, loss_scaler, su
                 'args': args,
             }
             save_on_master(to_save, checkpoint_path)
-            log_wandb_model(f"checkpoint{suffix}", checkpoint_path, epoch)
+            if upload and is_main_process():
+                log_wandb_model(f"checkpoint{suffix}", checkpoint_path, epoch)
             print("checkpoint sent to W&B (if)")
     else:
         client_state = {'epoch': epoch}
         model.save_checkpoint(save_dir=args.output_dir, tag=ckpt_name, client_state=client_state)
-        log_wandb_model(f"checkpoint{suffix}", output_dir / ckpt_name, epoch)
+        if upload and is_main_process():
+            log_wandb_model(f"checkpoint{suffix}", output_dir / ckpt_name, epoch)
         print("checkpoint sent to W&B (else)")
 
 
@@ -369,7 +369,7 @@ def load_model_FSC(args, model_without_ddp):
             del checkpoint['model']['pos_embed']
 
         model_without_ddp.load_state_dict(checkpoint['model'], strict=False)
-        print("Resume checkpoint %s" % args.resume)
+        print(f"Resume checkpoint {args.resume} ({checkpoint['epoch']})")
 
 def load_model_FSC1(args, model_without_ddp):
     if args.resume:
@@ -391,6 +391,30 @@ def load_model_FSC1(args, model_without_ddp):
         model_without_ddp.load_state_dict(checkpoint['model'], strict=False)
         model_without_ddp.load_state_dict(checkpoint1, strict=False)
         print("Resume checkpoint %s" % args.resume)
+
+
+def load_model_FSC_full(args, model_without_ddp, optimizer, loss_scaler):
+    if args.resume:
+        if args.resume.startswith('https'):
+            checkpoint = torch.hub.load_state_dict_from_url(
+                args.resume, map_location='cpu', check_hash=True)
+        else:
+            checkpoint = torch.load(args.resume, map_location='cpu')
+
+        if 'pos_embed' in checkpoint['model'] and checkpoint['model']['pos_embed'].shape != \
+                model_without_ddp.state_dict()['pos_embed'].shape:
+            print(f"Removing key pos_embed from pretrained checkpoint")
+            del checkpoint['model']['pos_embed']
+
+        model_without_ddp.load_state_dict(checkpoint['model'], strict=False)
+        print("Resume checkpoint %s" % args.resume)
+
+        if 'optimizer' in checkpoint and 'epoch' in checkpoint and args.do_resume:
+            optimizer.load_state_dict(checkpoint['optimizer'])
+            args.start_epoch = checkpoint['epoch'] + 1
+            if 'scaler' in checkpoint:
+                loss_scaler.load_state_dict(checkpoint['scaler'])
+            print("With optim & scheduler!")
 
 
 def all_reduce_mean(x):
@@ -478,3 +502,102 @@ def min_max(t):
     t /= t.max(1, keepdim=True)[0]
     t = t.view(*t_shape)
     return t
+
+
+
+timerfunc = time.perf_counter
+
+class measure_time(object):
+    def __enter__(self):
+        self.start = timerfunc()
+        return self
+
+    def __exit__(self, typ, value, traceback):
+        self.duration = timerfunc() - self.start
+
+    def __add__(self, other):
+        return self.duration + other.duration
+
+    def __sub__(self, other):
+        return self.duration - other.duration
+    
+    def __str__(self):
+        return str(self.duration)
+
+
+def log_test_results(test_dir):
+    test_dir = Path(test_dir)
+    logs = []
+    for d in test_dir.iterdir():
+        if d.is_dir():
+            if not (d / "log.txt").exists():
+                continue
+            print(d.name)
+            with open(d / "log.txt") as f:
+                j = json.load(f)
+                j['name'] = d.name
+                logs.append(j)
+    df = pd.DataFrame(logs)
+
+    df.sort_values('name', inplace=True, ignore_index=True)
+    cols = list(df.columns)
+    cols = cols[-1:] + cols[:-1]
+    df = df[cols]
+    # idx = df.index.tolist()
+    # idx.pop(0)
+    # df = df.reindex(idx+[0])
+
+    df.to_csv(test_dir / "logs.csv", index=False)
+
+
+COLORS = {
+    'muted blue': '#1f77b4',
+    'safety orange': '#ff7f0e',
+    'cooked asparagus green': '#2ca02c',
+    'brick red': '#d62728',
+    'muted purple': '#9467bd',
+    'chestnut brown': '#8c564b',
+    'raspberry yogurt pink': '#e377c2',
+    'middle gray': '#7f7f7f',
+    'curry yellow-green': '#bcbd22',
+    'blue-teal': '#17becf',
+    'muted blue light': '#419ede',
+    'safety orange light': '#ffa85b',
+    'cooked asparagus green light': '#4bce4b',
+    'brick red light': '#e36667'
+}
+
+
+def plot_test_results(test_dir):
+    import plotly.graph_objects as go
+    import plotly.io as pio
+
+    test_dir = Path(test_dir)
+    df = pd.read_csv(test_dir / "logs.csv")
+    # pio.renderers.default = "jpeg"
+
+    df['epoch'] = df['name'].str.split("_").str[1]
+    df_val = df[df['name'].str.contains("val")]
+    df_test = df[df['name'].str.contains("test")]
+
+    fig = go.Figure()
+    fig.add_trace(go.Scatter(x=df_test['epoch'], y=df_test['MAE'], line_color=COLORS['muted blue'],
+                        mode='lines', name='MAE_test'))
+    fig.add_trace(go.Scatter(x=df_test['epoch'], y=df_test['RMSE'], line_color=COLORS['safety orange'],
+                        mode='lines', name='RMSE_test'))
+    fig.add_trace(go.Scatter(x=df_test['epoch'], y=df_test['NAE'], line_color=COLORS['cooked asparagus green'],
+                        mode='lines', name='NAE_test'))
+    fig.add_trace(go.Scatter(x=df_test['epoch'], y=df_test['PPMAE'], line_color=COLORS['brick red'],
+                        mode='lines', name='PPMAE_test'))
+
+    fig.add_trace(go.Scatter(x=df_val['epoch'], y=df_val['MAE'], line_color=COLORS['muted blue light'],
+                        mode='lines', name='MAE_val', line=dict(dash='dot')))
+    fig.add_trace(go.Scatter(x=df_val['epoch'], y=df_val['RMSE'], line_color=COLORS['safety orange light'],
+                        mode='lines', name='RMSE_val', line=dict(dash='dot')))
+    fig.add_trace(go.Scatter(x=df_val['epoch'], y=df_val['NAE'], line_color=COLORS['cooked asparagus green light'],
+                        mode='lines', name='NAE_val', line=dict(dash='dot')))
+    fig.add_trace(go.Scatter(x=df_val['epoch'], y=df_val['PPMAE'], line_color=COLORS['brick red light'],
+                        mode='lines', name='PPMAE_val', line=dict(dash='dot')))
+    fig.update_yaxes(type="log")
+    fig.write_image(test_dir / "plot.jpeg", scale=4)
+    fig.write_html(test_dir / "plot.html", auto_open=False)


### PR DESCRIPTION
# Fine-tuning
(`FSC_finetune_cross.py`)

1. You can enable (default) or disable data augmentation with the flags `--do_aug` and `--no_do_aug`;
2. You can resume a training with the flag `--do_resume` (also resume the W&B run by providing the `--wandb_id`);
3. More efficient computation of training metrics (MAE and RMSE);
4. Validation during training, with MAE, RMSE and NAE (Normalized Average Error, i.e., $\frac{MAE}{\text{gt count}}$, as in https://arxiv.org/abs/2308.10468);
5. Logging of train and val metrics on W&B, plus updated images of the predictions and exemplars used for each image (as you can see in this report https://api.wandb.ai/links/giovanni-ficarra/ilxvm4to and in the images below);
6. Model saving:
	1. save last model locally at each epoch, overwriting the previous one (`finetuning_last`);
	2. save locally AND on W&B every `save_freq` epochs or at the end of the training (`finetuning_<epoch>`);
	3. save locally AND on W&B if the validation MAE is the lowest (`finetuning_minMAE`);
7. More flexibility on the training dataset by using the `data_path` from the command line argument in `FSC147.py` as in `FSC_finetune_cross.py`.

![image](https://github.com/Verg-Avesta/CounTR/assets/11423697/51189e6d-2df7-49bb-bf17-ae952e7cfc26)
![image](https://github.com/Verg-Avesta/CounTR/assets/11423697/5fcdb704-052a-4a54-844a-06d4411ee97a)


# Testing
(`FSC_test_cross(few-shot).py`)

1. More flexibility: you can test on the val split with the parameter `--split`;
2. Log NAE, loading time and inference time as well as MAE and RMSE;
3. Save better prediction images together with the exemplars used for each test image (particularly useful when using external exemplars), see examples here https://drive.google.com/file/d/134ac1x381PsaC3Y6RFXQWzpmlSzaoc3X/view?usp=sharing  and in the images below;
4. Log and plot test results with `util.misc.log_test_results` and `misc.plot_test_results`.

![full_5__103](https://github.com/Verg-Avesta/CounTR/assets/11423697/6757c2b8-fe6d-43a9-9de6-1a343a78fed1)
![boxes_5](https://github.com/Verg-Avesta/CounTR/assets/11423697/f43d1cc7-97b3-4356-92ff-8821f15b6331)
<img src='https://github.com/Verg-Avesta/CounTR/assets/11423697/56d8a0ca-f09c-460c-ab9e-2da23a0b102b' height='300'>

# Zero-shot demo

- `demo_zero.py` allows to test CounTR on your own data in an easy manner without providing any exemplar, just an input file or directory;
- For each input image, it will print the number of counted objects and the elapsed time;
- See examples of outputs here https://drive.google.com/file/d/134ac1x381PsaC3Y6RFXQWzpmlSzaoc3X/view?usp=sharing and in the image below;
- With `util.misc.frames2vid`, you can make a video from the output of the demo (particularly useful when dealing with video frames).

![viz_2](https://github.com/Verg-Avesta/CounTR/assets/11423697/af0e7632-c58f-41ea-85ec-71677bf86a65)


# run_minimal.MD

In this file I summarised how to finetune and test CounTR with the new parameters, with examples of commands and input images and configurations.
