### PR TITLE
Fixed model saving; handling of small images; new plots.

### DIFF
--- a/FSC_finetune_cross.py
+++ b/FSC_finetune_cross.py
@@ -408,11 +408,11 @@ def main(args):
             if args.output_dir and (epoch % save_freq == 0 or epoch + 1 == args.epochs) and epoch != 0:
                 misc.save_model(
                     args=args, model=model, model_without_ddp=model_without_ddp, optimizer=optimizer,
-                    loss_scaler=loss_scaler, epoch=epoch, suffix=f"finetuning_{epoch}", upload=epoch % 100 == 0)
-            elif True:
-                misc.save_model(
-                    args=args, model=model, model_without_ddp=model_without_ddp, optimizer=optimizer,
-                    loss_scaler=loss_scaler, epoch=epoch, suffix=f"finetuning_last", upload=False)
+                    loss_scaler=loss_scaler, epoch=epoch, suffix=f"finetuning_{epoch}",
+                    upload=((epoch + 1) % 100 == 0 or epoch + 1 == args.epochs))
+            misc.save_model(
+                args=args, model=model, model_without_ddp=model_without_ddp, optimizer=optimizer,
+                loss_scaler=loss_scaler, epoch=epoch, suffix="finetuning_last", upload=False)
             if args.output_dir and val_mae / len(data_loader_val) < min_MAE:
                 min_MAE = val_mae / len(data_loader_val)
                 misc.save_model(

--- a/FSC_test_cross(few-shot).py
+++ b/FSC_test_cross(few-shot).py
@@ -89,37 +89,38 @@ class TestData(Dataset):
         if external:
             self.external_boxes = []
             for anno in annotations:
-                rects = []
-                bboxes = annotations[anno]['box_examples_coordinates']
+                if anno in self.img:
+                    rects = []
+                    bboxes = annotations[anno]['box_examples_coordinates']
 
-                if bboxes:
-                    image = Image.open('{}/{}'.format(im_dir, anno))
-                    if image.mode == "RGBA":
-                        image = image.convert("RGB")
-                    image.load()
-                    W, H = image.size
+                    if bboxes:
+                        image = Image.open('{}/{}'.format(im_dir, anno))
+                        if image.mode == "RGBA":
+                            image = image.convert("RGB")
+                        image.load()
+                        W, H = image.size
 
-                    new_H = 384
-                    new_W = 16 * int((W / H * 384) / 16)
-                    scale_factor_W = float(new_W) / W
-                    scale_factor_H = float(new_H) / H
-                    image = transforms.Resize((new_H, new_W))(image)
-                    Normalize = transforms.Compose([transforms.ToTensor()])
-                    image = Normalize(image)
+                        new_H = 384
+                        new_W = 16 * int((W / H * 384) / 16)
+                        scale_factor_W = float(new_W) / W
+                        scale_factor_H = float(new_H) / H
+                        image = transforms.Resize((new_H, new_W))(image)
+                        Normalize = transforms.Compose([transforms.ToTensor()])
+                        image = Normalize(image)
 
-                    for bbox in bboxes:
-                        x1 = int(bbox[0][0] * scale_factor_W)
-                        y1 = int(bbox[0][1] * scale_factor_H)
-                        x2 = int(bbox[2][0] * scale_factor_W)
-                        y2 = int(bbox[2][1] * scale_factor_H)
-                        rects.append([y1, x1, y2, x2])
+                        for bbox in bboxes:
+                            x1 = int(bbox[0][0] * scale_factor_W)
+                            y1 = int(bbox[0][1] * scale_factor_H)
+                            x2 = int(bbox[2][0] * scale_factor_W)
+                            y2 = int(bbox[2][1] * scale_factor_H)
+                            rects.append([y1, x1, y2, x2])
 
-                    for box in rects:
-                        box2 = [int(k) for k in box]
-                        y1, x1, y2, x2 = box2[0], box2[1], box2[2], box2[3]
-                        bbox = image[:, y1:y2 + 1, x1:x2 + 1]
-                        bbox = transforms.Resize((64, 64))(bbox)
-                        self.external_boxes.append(bbox.numpy())
+                        for box in rects:
+                            box2 = [int(k) for k in box]
+                            y1, x1, y2, x2 = box2[0], box2[1], box2[2], box2[3]
+                            bbox = image[:, y1:y2 + 1, x1:x2 + 1]
+                            bbox = transforms.Resize((64, 64))(bbox)
+                            self.external_boxes.append(bbox.numpy())
 
             self.external_boxes = np.array(self.external_boxes if self.box_bound < 0 else
                                            self.external_boxes[:self.box_bound])

--- a/FSC_test_cross(few-shot).py
+++ b/FSC_test_cross(few-shot).py
@@ -56,6 +56,8 @@ def get_args_parser():
     parser.add_argument('--box_bound', default=-1, type=int,
                         help='The max number of exemplars to be considered')
     parser.add_argument('--split', default="test", type=str)
+    parser.add_argument('--max_s_cnt', default=1, type=int,
+                        help="The max number of small exemplars for splitting the image in a grid")
 
     # Training parameters
     parser.add_argument('--num_workers', default=0, type=int)
@@ -268,7 +270,7 @@ def main(args):
                 if rect[2] - rect[0] < 10 and rect[3] - rect[1] < 10:
                     s_cnt += 1
 
-            if s_cnt >= 1:
+            if s_cnt >= args.max_s_cnt:
                 r_images = []
                 r_densities = []
                 r_images.append(TF.crop(samples[0], 0, 0, int(h / 3), int(w / 3)))
@@ -364,7 +366,7 @@ def main(args):
 
             if gt_cnt == 0:
                 empties.append(im_name.name)
-            print(f'{data_iter_step}/{len(data_loader_test)}: pred_cnt: {pred_cnt:5.3f},  gt_cnt: {gt_cnt:5.3f},  error: {cnt_err:5.3f},  AE: {cnt_err:5.3f},  SE: {cnt_err ** 2:5.3f}, id: {im_name.name}, s_cnt: {s_cnt >= 1}')
+            print(f'{data_iter_step}/{len(data_loader_test)}: pred_cnt: {pred_cnt:5.3f},  gt_cnt: {gt_cnt:5.3f},  error: {cnt_err:5.3f},  AE: {cnt_err:5.3f},  SE: {cnt_err ** 2:5.3f}, id: {im_name.name}, s_cnt: {s_cnt >= args.max_s_cnt}')
 
             loss_array.append(cnt_err)
             gt_array.append(gt_cnt)
@@ -378,19 +380,8 @@ def main(args):
         sam = samples[0]
         gt_img = torch.cat((gt_map, torch.zeros_like(gt_map), torch.zeros_like(gt_map))).to(device=device)
         box_map = misc.get_box_map(sam, pos, device, args.external)
-        pred_img = density_map.unsqueeze(0) if s_cnt < 1 else misc.make_grid(r_densities, h, w).unsqueeze(0)
-        pred_img = torch.cat((pred_img, torch.zeros_like(pred_img), torch.zeros_like(pred_img)))
-
-        den_gt = Image.new(mode="RGB", size=(w, h), color=(0, 0, 0))
-        if gt_cnt != 0:
-            draw = ImageDraw.Draw(den_gt)
-            draw.text((w-50, h-50), f"{gt_cnt:.3f}", (255, 255, 255))
-            den_gt = np.array(den_gt).transpose((2, 0, 1))
-            den_gt = torch.tensor(np.array(den_gt), device=device)
-            den_gt = sam * 0.6 + den_gt + gt_img
-            den_gt = torch.clamp(den_gt, 0, 1)
-
-        sam_box = torch.clamp(sam + box_map, 0, 1)
+        pred_img = density_map.unsqueeze(0) if s_cnt < args.max_s_cnt else misc.make_grid(r_densities, h, w).unsqueeze(0)
+        pred_img = torch.cat((pred_img, pred_img, torch.zeros_like(pred_img)))
 
         den_pr = Image.new(mode="RGB", size=(w, h), color=(0, 0, 0))
         draw = ImageDraw.Draw(den_pr)
@@ -401,15 +392,37 @@ def main(args):
         den_pr = torch.clamp(den_pr, 0, 1)
 
         if gt_cnt != 0:
-            full = torch.cat((den_gt, sam_box, den_pr), -1)
-        else:
-            full = torch.cat((sam_box, den_pr), -1)
-        torchvision.utils.save_image(full, (os.path.join(args.output_dir, f'full_{im_name.stem}__{round(pred_cnt)}{im_name.suffix}')))
+            fp_img = torch.zeros_like(pred_img)
+            mask = (gt_img - pred_img) < -0.01
+            fp_img[mask] = pred_img[mask]
+            tp_img = sam * 0.6 + (pred_img - fp_img)[[1, 0, 2], ...]
 
-        # if args.external:
+            mix1 = (pred_img.clamp(0, 1) - gt_img.clamp(0, 1)).abs()
+            mix2 = sam * 0.6 + mix1
+            
+            labels = Image.new(mode="RGB", size=(w, h), color=(0, 0, 0))
+            draw = ImageDraw.Draw(labels)
+            draw.text((w-150, h-130), f"GT: {gt_cnt:.3f}", (255, 255, 255))
+            draw.text((w-150, h-110), f"Pred: {pred_cnt:.3f}", (255, 255, 255))
+            draw.text((w-150, h-90), "True Positives", (0, 255, 0))
+            draw.text((w-150, h-70), "False Positives", (255, 255, 0))
+            draw.text((w-150, h-50), "False Negatives", (255, 0, 0))
+            labels = np.array(labels).transpose((2, 0, 1))
+            labels = torch.tensor(np.array(labels), device=device)
+
+            tp_cnt = (pred_img - fp_img).sum() / 60
+            print(f"{tp_cnt=}")
+
+            sam_box = torch.clamp(sam + box_map + labels, 0, 1)
+            full = torch.cat((mix2, sam_box, tp_img), -1)
+        else:
+            sam_box = torch.clamp(sam + box_map, 0, 1)
+            full = torch.cat((sam_box, den_pr), -1)
+        torchvision.utils.save_image(full, (os.path.join(args.output_dir, f'full_{im_name.stem}__{round(pred_cnt)}.png')))
+
         if num_boxes > 0:
             boxes_img = torch.cat([boxes[x, :, :, :] for x in range(boxes.shape[0])], 2)
-            torchvision.utils.save_image(boxes_img, (os.path.join(args.output_dir, f'boxes_{im_name.stem}{im_name.suffix}')))
+            torchvision.utils.save_image(boxes_img, (os.path.join(args.output_dir, f'boxes_{im_name.stem}.png')))
 
         torch.cuda.synchronize()
 

--- a/util/misc.py
+++ b/util/misc.py
@@ -466,22 +466,22 @@ def plot_counts(res_csv: Union[str, list[str]], output_dir: str, suffix: str = "
     plt.savefig(os.path.join(output_dir, f'counts{suffix}.png'), dpi=300)
 
 
-def write_zeroshot_annotations(p: Path):
-    with open(p / 'annotations.json', 'a') as split:
-        split.write('{\n')
-        for img in p.iterdir():
+def write_zeroshot_annotations(p: Path, h: int = 960, w: int = 1280):
+    with open(p / 'annotations.json', 'a') as anno:
+        anno.write('{\n')
+        for img in (p / "images").iterdir():
             if img.is_file():
-                split.write(f'  "{img.name}": {{\n' \
-                            '    "H": 960,\n' \
-                            '    "W": 1280,\n' \
+                anno.write(f'  "{img.name}": {{\n' \
+                            f'    "H": {h},\n' \
+                            f'    "W": {w},\n' \
                             '    "box_examples_coordinates": [],\n' \
                             '    "points": []\n' \
                             '  },\n')
-        split.write("}")
+        anno.write("}")
 
     with open(p / 'split.json', 'a') as split:
         split.write('{\n  "test":\n  [\n')
-        for img in p.iterdir():
+        for img in (p / "images").iterdir():
             if img.is_file():
                 split.write(f'    "{img.name}",\n')
         split.write("  ]\n}")
@@ -605,7 +605,7 @@ def plot_test_results(test_dir):
     fig.write_html(test_dir / "plot.html", auto_open=False)
 
 
-def frames2vid(input_dir: str, output_file: str, pattern: str, fps: int, h=720, w=1280):
+def frames2vid(input_dir: str, output_file: str, pattern: str, fps: int = 10, h=720, w=1280):
     input_dir = Path(input_dir)
     video_file = None
     files = sorted(input_dir.glob(pattern))


### PR DESCRIPTION
## Fine-tuning

- Fixed and improved the way models are saved:
	- The .pth file with suffix `finetuning_last`, which contains the last weights of the model during fine-tuning and is updated for each epoch, for being able to resume the training at any time, didn't include the actual _last model_ of the whole training. Now it does.
	- The .pth files with suffix `finetuning_<epoch>` are uploaded on W&B every 100 epochs and on the last epoch.
- Now it should be possible to finetune CounTR on images smaller than 384x384 px, which are upscaled during data loading to fit the size requirement.


## Testing
 - Updated test with external exemplars: now you can use different exemplars for different subsets, defining different test splits in the json split file.
 - New param `max_s_cnt`: the max number of small exemplars which is tolerated before splitting the image in a grid (i.e., if the number of small objects among the exemplars is less than `max_s_cnt` the image is processed as a whole, otherwise it is splitted in 9 parts).
 - New plots which show an approximate yet intuitive visualization of True Positives (in green - the predictions that matche with the GT), False Positives (in yellow -- the other predictions), False Negatives (in red - the missed predictions), based on color subtraction.

![image](https://github.com/Verg-Avesta/CounTR/assets/11423697/cacb2625-6142-41ce-94e9-e95fab68ea8f)
![image](https://github.com/Verg-Avesta/CounTR/assets/11423697/2e8bb15c-2ab4-480e-8323-81d2aad44957)
![image](https://github.com/Verg-Avesta/CounTR/assets/11423697/2339932c-bf38-42ef-927f-c58651c23955)
(images from the [Video Object Counting Dataset](https://github.com/ojmakhura/voc-18))