### PR TITLE
Add HF integration

### DIFF
--- a/models_mae_cross.py
+++ b/models_mae_cross.py
@@ -15,7 +15,11 @@ from models_crossvit import CrossAttentionBlock
 
 from util.pos_embed import get_2d_sincos_pos_embed
 
-class SupervisedMAE(nn.Module):
+from huggingface_hub import PyTorchModelHubMixin
+
+
+class SupervisedMAE(nn.Module, PyTorchModelHubMixin,
+                    repo_url="https://github.com/Verg-Avesta/CounTR", pipeline_tag="zero-shot-image-classification", license="mit"):
     def __init__(self, img_size=384, patch_size=16, in_chans=3,
                  embed_dim=1024, depth=24, num_heads=16,
                  decoder_embed_dim=512, decoder_depth=2, decoder_num_heads=16,

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ pandas==1.5.2
 six==1.16.0
 wandb
 tqdm
+huggingface_hub>=0.24.6


### PR DESCRIPTION
Hi @Verg-Avesta and team,

Thanks for this nice work! 

I wrote a quick PoC to showcase that you can easily have integration with the 🤗 hub so that you can automatically load the various CounTR models using `from_pretrained` (and push them using `push_to_hub`), track download numbers for your models (similar to models in the Transformers library), have nice model cards on a per-model basis, and leverage `safetensors` for serialization. It leverages the [PyTorchModelHubMixin](https://huggingface.co/docs/huggingface_hub/package_reference/mixins#huggingface_hub.PyTorchModelHubMixin) class which allows to inherits these methods.

This way, people can also find your models easier, as currently they are hosted on Google Drive.

Usage is as follows:

```python
from models_mae_cross import SupervisedMAE

# load model
model = SupervisedMAE()

# load weights
model.load_state_dict(...)

# push to the hub
model.push_to_hub("your-hf-org-or-username/countr-finetuned-fsc147")

# reload
model = SupervisedMAE.from_pretrained("your-hf-org-or-username/countr-finetuned-fsc147")
```

This means people don't need to manually download a checkpoint first in their local environment, it just loads automatically from the hub. 

Would you be interested in this integration?

Kind regards,

Niels

# Note

Please don't merge this PR before pushing the model to the hub :)